### PR TITLE
Complete admin setup flow (T4)

### DIFF
--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/addapartamento/AddApartamentoViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/addapartamento/AddApartamentoViewModel.kt
@@ -29,6 +29,10 @@ class AddApartamentoViewModel(
     val uiState: StateFlow<AddApartamentoUiState> = _uiState.asStateFlow()
 
 
+    fun reset() {
+        _uiState.update { AddApartamentoUiState() }
+    }
+
     fun setCondominioId(condominioId: String) {
         _uiState.update { it.copy(condominioId = condominioId) }
     }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/addcondominio/AddCondominioViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/addcondominio/AddCondominioViewModel.kt
@@ -25,6 +25,10 @@ class AddCondominioViewModel(
     private val _uiState = MutableStateFlow(AddCondominioUiState())
     val uiState: StateFlow<AddCondominioUiState> = _uiState.asStateFlow()
 
+    fun reset() {
+        _uiState.update { AddCondominioUiState() }
+    }
+
     fun setNome(nome: String) {
         _uiState.update { it.copy(form = it.form.copy(nome = nome), errorMessage = null) }
     }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/addmorador/navigation/AddMoradorNavHost.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/addmorador/navigation/AddMoradorNavHost.kt
@@ -61,9 +61,7 @@ fun NavGraphBuilder.addMoradorNavGraph( // TODO: Improve this flow to make it le
                 pessoaId,
                 apartamentoId
             ) {
-                navController.popBackStack()
-                navController.popBackStack()
-                navController.popBackStack()
+                navController.popBackStack(AddMoradorRoute, inclusive = true)
             }
         }
     }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/adminhome/AdminHomeViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/adminhome/AdminHomeViewModel.kt
@@ -5,14 +5,18 @@ import androidx.lifecycle.viewModelScope
 import com.zalamena.condominios.condominio.domain.condominio.usecase.GetCondominiosUseCase
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.models.CondominioSummaryUiData
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.toSummaryUi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+private const val MIN_LOADING_MS = 1000L
+
 data class AdminHomeUiState(
     val condominios: List<CondominioSummaryUiData> = emptyList(),
-    val isLoading: Boolean = false,
+    val isLoading: Boolean = true,
     val isError: Boolean = false,
     val navigationEvent: AdminHomeNavigationEvent? = null
 )
@@ -31,9 +35,12 @@ class AdminHomeViewModel(
 
     fun loadCondominios() {
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = it.condominios.isEmpty(), isError = false) }
+            val showSpinner = _uiState.value.condominios.isEmpty()
+            _uiState.update { it.copy(isLoading = showSpinner, isError = false) }
 
+            val minDelay = if (showSpinner) async { delay(MIN_LOADING_MS) } else null
             val result = getCondominiosUseCase()
+            minDelay?.await()
 
             when {
                 result.isSuccess -> {

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.zalamena.condominios.condominio.ui.apartamento.detail
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,17 +13,21 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.zalamena.condominios.common.ui.components.loading.FullscreenLoading
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.zalamena.condominios.condominio.ui.apartamento.detail.models.MoradorDetailUiData
 
 @Composable
@@ -32,8 +37,15 @@ fun ApartamentoDetailScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
-    LaunchedEffect(uiState.apartamentoId) {
-        viewModel.load()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.load()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     LaunchedEffect(uiState.navigationEvent) {
@@ -46,12 +58,25 @@ fun ApartamentoDetailScreen(
         }
     }
 
-    ApartamentoDetailContent(
-        uiState = uiState,
-        onAddMoradorClick = viewModel::onAddMoradorClick
-    )
-
-    FullscreenLoading(isLoading = uiState.isLoading)
+    Box(modifier = Modifier.fillMaxSize()) {
+        when {
+            uiState.isLoading -> {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            }
+            uiState.isError -> {
+                Text(
+                    text = "Erro ao carregar apartamento",
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+            else -> {
+                ApartamentoDetailContent(
+                    uiState = uiState,
+                    onAddMoradorClick = viewModel::onAddMoradorClick
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailViewModel.kt
@@ -7,18 +7,22 @@ import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradoresFo
 import com.zalamena.condominios.condominio.ui.apartamento.detail.models.MoradorDetailUiData
 import com.zalamena.condominios.condominio.ui.apartamento.detail.models.maskCpf
 import com.zalamena.condominios.condominio.ui.apartamento.detail.models.toLabel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+private const val MIN_LOADING_MS = 1000L
+
 data class ApartamentoDetailUiState(
     val apartamentoId: String = "",
     val numero: String = "",
     val andar: String = "",
     val moradores: List<MoradorDetailUiData> = emptyList(),
-    val isLoading: Boolean = false,
+    val isLoading: Boolean = true,
     val isError: Boolean = false,
     val navigationEvent: ApartamentoDetailNavEvent? = null
 )
@@ -44,10 +48,13 @@ class ApartamentoDetailViewModel(
         if (apartamentoId.isBlank()) return
 
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, isError = false) }
+            val showSpinner = _uiState.value.numero.isBlank()
+            _uiState.update { it.copy(isLoading = showSpinner, isError = false) }
 
+            val minDelay = if (showSpinner) async { delay(MIN_LOADING_MS) } else null
             val aptResult = getApartamentoUseCase(apartamentoId)
             val moradoresResult = getMoradoresForApartamentoUseCase(apartamentoId)
+            minDelay?.await()
 
             when {
                 aptResult.isSuccess && moradoresResult.isSuccess -> {

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardScreen.kt
@@ -2,6 +2,7 @@ package com.zalamena.condominios.condominio.ui.condominio.dashboard
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,25 +14,27 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
-import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.models.ApartamentoDashboardUiData
-import com.zalamena.condominios.condominio.ui.condominio.dashboard.models.CondominioSummaryUiData
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CondominioDashboardScreen(
     viewModel: CondominioDashboardViewModel,
@@ -40,8 +43,15 @@ fun CondominioDashboardScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
-    LaunchedEffect(Unit) {
-        viewModel.loadCondominios()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.loadCondominios()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     LaunchedEffect(uiState.navigationEvent) {
@@ -58,79 +68,56 @@ fun CondominioDashboardScreen(
         }
     }
 
-    CondominioDashboardContent(
-        uiState = uiState,
-        onCondominioSelected = viewModel::selectCondominio,
-        onAddApartamentoClick = viewModel::onAddApartamentoClick,
-        onApartamentoClick = viewModel::onApartamentoClick
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun CondominioDashboardContent(
-    uiState: CondominioDashboardUiState,
-    onCondominioSelected: (String) -> Unit = {},
-    onAddApartamentoClick: () -> Unit = {},
-    onApartamentoClick: (String) -> Unit = {}
-) {
-    Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp)
-    ) {
-        Text("Dashboard", style = MaterialTheme.typography.headlineMedium)
-        Spacer(Modifier.height(16.dp))
-
-        CondominioSelector(
-            condominios = uiState.condominios,
-            selectedId = uiState.selectedCondominioId,
-            onSelected = onCondominioSelected
-        )
-
-        if (uiState.selectedCondominioId != null) {
-            Spacer(Modifier.height(12.dp))
-            Text("Total: ${uiState.totalApartamentos} apartamento(s)")
-            Spacer(Modifier.height(8.dp))
-            Button(onClick = onAddApartamentoClick, modifier = Modifier.fillMaxWidth()) {
-                Text("+ Adicionar Apartamento")
-            }
-            Spacer(Modifier.height(8.dp))
-            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                items(uiState.apartamentos) { apt ->
-                    ApartamentoCard(apt, onClick = { onApartamentoClick(apt.id) })
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(uiState.condominioNome.ifBlank { "Apartamentos" }) })
+        },
+        floatingActionButton = {
+            if (!uiState.isLoading && !uiState.isError) {
+                FloatingActionButton(onClick = { viewModel.onAddApartamentoClick() }) {
+                    Text("+")
                 }
             }
         }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun CondominioSelector(
-    condominios: List<CondominioSummaryUiData>,
-    selectedId: String?,
-    onSelected: (String) -> Unit
-) {
-    var expanded by remember { mutableStateOf(false) }
-    val selectedLabel = condominios.find { it.id == selectedId }?.nome ?: "Selecione um condomínio"
-
-    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
-        TextField(
-            value = selectedLabel,
-            onValueChange = {},
-            readOnly = true,
-            label = { Text("Condomínio") },
-            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
-            modifier = Modifier.menuAnchor().fillMaxWidth()
-        )
-        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            condominios.forEach { condominio ->
-                DropdownMenuItem(
-                    text = { Text(condominio.nome) },
-                    onClick = {
-                        onSelected(condominio.id)
-                        expanded = false
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when {
+                uiState.isLoading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+                uiState.isError -> {
+                    Text(
+                        text = "Erro ao carregar apartamentos",
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+                uiState.apartamentos.isEmpty() -> {
+                    Column(
+                        modifier = Modifier.align(Alignment.Center),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text("Nenhum apartamento cadastrado")
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Button(onClick = { viewModel.onAddApartamentoClick() }) {
+                            Text("Criar primeiro apartamento")
+                        }
                     }
-                )
+                }
+                else -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        item { Spacer(Modifier.height(8.dp)) }
+                        item {
+                            Text("Total: ${uiState.totalApartamentos} apartamento(s)")
+                            Spacer(Modifier.height(8.dp))
+                        }
+                        items(uiState.apartamentos) { apt ->
+                            ApartamentoCard(apt, onClick = { viewModel.onApartamentoClick(apt.id) })
+                        }
+                    }
+                }
             }
         }
     }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardViewModel.kt
@@ -5,18 +5,21 @@ import androidx.lifecycle.viewModelScope
 import com.zalamena.condominios.condominio.domain.condominio.models.Condominio
 import com.zalamena.condominios.condominio.domain.condominio.usecase.GetCondominiosUseCase
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.models.ApartamentoDashboardUiData
-import com.zalamena.condominios.condominio.ui.condominio.dashboard.models.CondominioSummaryUiData
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+private const val MIN_LOADING_MS = 1000L
+
 data class CondominioDashboardUiState(
-    val condominios: List<CondominioSummaryUiData> = emptyList(),
-    val selectedCondominioId: String? = null,
+    val condominioId: String = "",
+    val condominioNome: String = "",
     val apartamentos: List<ApartamentoDashboardUiData> = emptyList(),
     val totalApartamentos: Int = 0,
-    val isLoading: Boolean = false,
+    val isLoading: Boolean = true,
     val isError: Boolean = false,
     val navigationEvent: DashboardNavigationEvent? = null
 )
@@ -33,26 +36,37 @@ class CondominioDashboardViewModel(
     private val _uiState = MutableStateFlow(CondominioDashboardUiState())
     val uiState: StateFlow<CondominioDashboardUiState> = _uiState
 
-    private var loadedCondominios: List<Condominio> = emptyList()
+    fun setCondominioId(condominioId: String) {
+        _uiState.update { it.copy(condominioId = condominioId) }
+    }
 
     fun loadCondominios() {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, isError = false) }
+        val condominioId = _uiState.value.condominioId
+        if (condominioId.isBlank()) return
 
+        viewModelScope.launch {
+            val showSpinner = _uiState.value.apartamentos.isEmpty()
+            _uiState.update { it.copy(isLoading = showSpinner, isError = false) }
+
+            val minDelay = if (showSpinner) async { delay(MIN_LOADING_MS) } else null
             val result = getCondominiosUseCase()
+            minDelay?.await()
 
             when {
                 result.isSuccess -> {
-                    loadedCondominios = result.getOrThrow()
-                    val currentSelectedId = _uiState.value.selectedCondominioId
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            condominios = loadedCondominios.map { c -> c.toSummaryUi() }
-                        )
-                    }
-                    if (currentSelectedId != null) {
-                        selectCondominio(currentSelectedId)
+                    val condominio = result.getOrThrow().find { it.id == condominioId }
+                    if (condominio != null) {
+                        val apartamentos = condominio.apartamentos.map { it.toDashboardUi() }
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                condominioNome = condominio.nome,
+                                apartamentos = apartamentos,
+                                totalApartamentos = apartamentos.size
+                            )
+                        }
+                    } else {
+                        _uiState.update { it.copy(isLoading = false, isError = true) }
                     }
                 }
                 result.isFailure -> {
@@ -62,21 +76,9 @@ class CondominioDashboardViewModel(
         }
     }
 
-    fun selectCondominio(condominioId: String) {
-        val condominio = loadedCondominios.find { it.id == condominioId } ?: return
-        val apartamentos = condominio.apartamentos.map { it.toDashboardUi() }
-
-        _uiState.update {
-            it.copy(
-                selectedCondominioId = condominioId,
-                apartamentos = apartamentos,
-                totalApartamentos = apartamentos.size
-            )
-        }
-    }
-
     fun onAddApartamentoClick() {
-        val condominioId = _uiState.value.selectedCondominioId ?: return
+        val condominioId = _uiState.value.condominioId
+        if (condominioId.isBlank()) return
         _uiState.update { it.copy(navigationEvent = DashboardNavigationEvent.AddApartamento(condominioId)) }
     }
 

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/CondominioDashboardNavHost.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/CondominioDashboardNavHost.kt
@@ -35,6 +35,7 @@ fun NavGraphBuilder.condominioDashboardNavHost(
             CondominioDashboardScreen(
                 viewModel = viewModel,
                 onNavigateToAddApartamento = { condominioId ->
+                    addApartamentoViewModel.reset()
                     addApartamentoViewModel.setCondominioId(condominioId)
                     navController.navigate(AddApartamentoRoute)
                 },

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/addapartamento/AddApartamentoViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/addapartamento/AddApartamentoViewModelTest.kt
@@ -115,6 +115,29 @@ class AddApartamentoViewModelTest : TestsWithMocks() {
         assertFalse(viewModel.uiState.value.isLoading)
     }
 
+    // --- reset ---
+
+    @Test
+    fun `GIVEN form filled and apartamento created WHEN reset THEN state is cleared`() = runTest(testScheduler) {
+        viewModel.setCondominioId("condominioId")
+        viewModel.setNumeroApartamento("101")
+        viewModel.setAndarApartamento("1")
+
+        everySuspending { apartamentosRepository.addApartamento(isAny(), isAny()) } returns Result.success("newId")
+        viewModel.addApartamento()
+        advanceUntilIdle()
+
+        viewModel.reset()
+
+        val state = viewModel.uiState.value
+        assertEquals("", state.condominioId)
+        assertNull(state.createdApartamentoId)
+        assertNull(state.errorMessage)
+        assertFalse(state.isLoading)
+        assertEquals("", state.addApartamentoForm.numero)
+        assertEquals("", state.addApartamentoForm.andar)
+    }
+
     override fun setUpMocks() {
         mocker.injectMocks(this)
     }

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/addcondominio/AddCondominioViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/addcondominio/AddCondominioViewModelTest.kt
@@ -132,6 +132,25 @@ class AddCondominioViewModelTest : TestsWithMocks() {
         assertNull(viewModel.uiState.value.errorMessage)
     }
 
+    // --- reset ---
+
+    @Test
+    fun `GIVEN form filled and condominio created WHEN reset THEN state is cleared`() = runTest {
+        fillValidForm()
+        everySuspending { condominioRepository.getCondominios() } returns Result.success(emptyList())
+        everySuspending { condominioRepository.addCondominio(isAny()) } returns Result.success(Unit)
+        viewModel.addCondominio()
+
+        viewModel.reset()
+
+        val state = viewModel.uiState.value
+        assertNull(state.createdCondominioId)
+        assertNull(state.errorMessage)
+        assertFalse(state.isLoading)
+        assertTrue(state.form.nome.isBlank())
+        assertTrue(state.form.rua.isBlank())
+    }
+
     // --- Helpers ---
 
     private fun fillValidForm() {

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/adminhome/AdminHomeViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/adminhome/AdminHomeViewModelTest.kt
@@ -55,8 +55,8 @@ class AdminHomeViewModelTest : TestsWithMocks() {
     }
 
     @Test
-    fun `GIVEN initial state THEN not loading`() = runTest(testScheduler) {
-        assertFalse(viewModel.uiState.value.isLoading)
+    fun `GIVEN initial state THEN is loading`() = runTest(testScheduler) {
+        assertTrue(viewModel.uiState.value.isLoading)
     }
 
     @Test

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/condominio/CondominioDashboardViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/condominio/CondominioDashboardViewModelTest.kt
@@ -51,13 +51,13 @@ class CondominioDashboardViewModelTest : TestsWithMocks() {
     // --- Initial state ---
 
     @Test
-    fun `GIVEN initial state WHEN observing THEN isLoading is false`() = runTest(testScheduler) {
-        assertFalse(viewModel.uiState.value.isLoading)
+    fun `GIVEN initial state WHEN observing THEN isLoading is true`() = runTest(testScheduler) {
+        assertTrue(viewModel.uiState.value.isLoading)
     }
 
     @Test
-    fun `GIVEN initial state WHEN observing THEN condominios list is empty`() = runTest(testScheduler) {
-        assertEquals(emptyList(), viewModel.uiState.value.condominios)
+    fun `GIVEN initial state WHEN observing THEN apartamentos list is empty`() = runTest(testScheduler) {
+        assertEquals(emptyList(), viewModel.uiState.value.apartamentos)
     }
 
     @Test
@@ -73,108 +73,69 @@ class CondominioDashboardViewModelTest : TestsWithMocks() {
     // --- loadCondominios ---
 
     @Test
-    fun `GIVEN condominios available WHEN loading THEN populates condominios list`() = runTest(testScheduler) {
-        everySuspending { condominioRepository.getCondominios() } returns Result.success(listOf(Condominio.dummy))
-
-        viewModel.loadCondominios()
-        advanceUntilIdle()
+    fun `GIVEN condominioId set WHEN loading THEN populates apartamentos`() = runTest(testScheduler) {
+        loadCondominio(Condominio.dummy)
 
         val state = viewModel.uiState.value
         assertFalse(state.isLoading)
         assertFalse(state.isError)
-        assertEquals(1, state.condominios.size)
-        assertEquals(Condominio.dummy.id, state.condominios.first().id)
-        assertEquals(Condominio.dummy.nome, state.condominios.first().nome)
+        assertEquals(Condominio.dummy.apartamentos.size, state.apartamentos.size)
+        assertEquals(Condominio.dummy.nome, state.condominioNome)
     }
 
     @Test
-    fun `GIVEN fetch fails WHEN loading condominios THEN sets error state`() = runTest(testScheduler) {
+    fun `GIVEN fetch fails WHEN loading THEN sets error state`() = runTest(testScheduler) {
         everySuspending { condominioRepository.getCondominios() } returns Result.failure(Exception("DB error"))
 
+        viewModel.setCondominioId(Condominio.dummy.id)
         viewModel.loadCondominios()
         advanceUntilIdle()
 
         val state = viewModel.uiState.value
         assertFalse(state.isLoading)
         assertTrue(state.isError)
-        assertEquals(emptyList(), state.condominios)
     }
 
     @Test
-    fun `GIVEN no condominios WHEN loading THEN condominios list is empty`() = runTest(testScheduler) {
+    fun `GIVEN condominio not found WHEN loading THEN sets error state`() = runTest(testScheduler) {
         everySuspending { condominioRepository.getCondominios() } returns Result.success(emptyList())
 
+        viewModel.setCondominioId("unknown-id")
         viewModel.loadCondominios()
         advanceUntilIdle()
 
         val state = viewModel.uiState.value
         assertFalse(state.isLoading)
-        assertFalse(state.isError)
-        assertEquals(emptyList(), state.condominios)
-    }
-
-    // --- selectCondominio ---
-
-    @Test
-    fun `GIVEN condominio loaded WHEN selecting it THEN updates selectedCondominioId`() = runTest(testScheduler) {
-        loadCondominio(Condominio.dummy)
-
-        viewModel.selectCondominio(Condominio.dummy.id)
-
-        assertEquals(Condominio.dummy.id, viewModel.uiState.value.selectedCondominioId)
+        assertTrue(state.isError)
     }
 
     @Test
-    fun `GIVEN condominio loaded WHEN selecting it THEN populates apartamentos list`() = runTest(testScheduler) {
-        loadCondominio(Condominio.dummy)
+    fun `GIVEN no condominioId WHEN loading THEN does nothing`() = runTest(testScheduler) {
+        viewModel.loadCondominios()
+        advanceUntilIdle()
 
-        viewModel.selectCondominio(Condominio.dummy.id)
-
-        val apartamentos = viewModel.uiState.value.apartamentos
-        assertEquals(Condominio.dummy.apartamentos.size, apartamentos.size)
-        assertEquals(Condominio.dummy.apartamentos.first().id, apartamentos.first().id)
+        assertTrue(viewModel.uiState.value.isLoading)
     }
 
+    // --- apartamento counts ---
+
     @Test
-    fun `GIVEN condominio with apartamentos WHEN selecting THEN totalApartamentos is correct`() = runTest(testScheduler) {
+    fun `GIVEN condominio with apartamentos WHEN loading THEN totalApartamentos is correct`() = runTest(testScheduler) {
         val apt1 = Apartamento.dummy
         val apt2 = Apartamento.dummy.copy(id = "apt2", moradores = emptyList())
         val condominio = Condominio.dummy.copy(apartamentos = listOf(apt1, apt2))
 
         loadCondominio(condominio)
-        viewModel.selectCondominio(condominio.id)
 
         assertEquals(2, viewModel.uiState.value.totalApartamentos)
     }
 
     @Test
-    fun `GIVEN apartment with moradores WHEN selecting condominio THEN moradorCount is correct`() = runTest(testScheduler) {
+    fun `GIVEN apartment with moradores WHEN loading THEN moradorCount is correct`() = runTest(testScheduler) {
         loadCondominio(Condominio.dummy)
-
-        viewModel.selectCondominio(Condominio.dummy.id)
 
         val apt = viewModel.uiState.value.apartamentos.first()
         assertEquals(Apartamento.dummy.moradores.size, apt.moradorCount)
-    }
-
-    @Test
-    fun `GIVEN apartment with no moradores WHEN selecting condominio THEN moradorCount is zero`() = runTest(testScheduler) {
-        val empty = Apartamento.dummy.copy(moradores = emptyList())
-        loadCondominio(Condominio.dummy.copy(apartamentos = listOf(empty)))
-
-        viewModel.selectCondominio(Condominio.dummy.id)
-
-        assertEquals(0, viewModel.uiState.value.apartamentos.first().moradorCount)
-    }
-
-    @Test
-    fun `GIVEN unknown condominioId WHEN selecting THEN state does not change`() = runTest(testScheduler) {
-        loadCondominio(Condominio.dummy)
-
-        viewModel.selectCondominio("unknown-id")
-
-        assertNull(viewModel.uiState.value.selectedCondominioId)
-        assertEquals(emptyList(), viewModel.uiState.value.apartamentos)
     }
 
     // --- Navigation events ---
@@ -182,11 +143,12 @@ class CondominioDashboardViewModelTest : TestsWithMocks() {
     @Test
     fun `WHEN add apartamento clicked THEN navigation event is AddApartamento`() = runTest(testScheduler) {
         loadCondominio(Condominio.dummy)
-        viewModel.selectCondominio(Condominio.dummy.id)
 
         viewModel.onAddApartamentoClick()
 
-        assertIs<DashboardNavigationEvent.AddApartamento>(viewModel.uiState.value.navigationEvent)
+        val event = viewModel.uiState.value.navigationEvent
+        assertIs<DashboardNavigationEvent.AddApartamento>(event)
+        assertEquals(Condominio.dummy.id, event.condominioId)
     }
 
     @Test
@@ -199,39 +161,17 @@ class CondominioDashboardViewModelTest : TestsWithMocks() {
     }
 
     @Test
-    fun `GIVEN AddApartamento nav event WHEN handled THEN navigation event is cleared`() = runTest(testScheduler) {
-        loadCondominio(Condominio.dummy)
-        viewModel.selectCondominio(Condominio.dummy.id)
-        viewModel.onAddApartamentoClick()
-        viewModel.onNavigationHandled()
-
-        assertNull(viewModel.uiState.value.navigationEvent)
-    }
-
-    @Test
-    fun `GIVEN ApartamentoDetails nav event WHEN handled THEN navigation event is cleared`() = runTest(testScheduler) {
+    fun `GIVEN nav event WHEN handled THEN navigation event is cleared`() = runTest(testScheduler) {
         viewModel.onApartamentoClick("apt-123")
         viewModel.onNavigationHandled()
 
         assertNull(viewModel.uiState.value.navigationEvent)
     }
 
-    @Test
-    fun `WHEN add apartamento clicked with condominio selected THEN navigation event carries the condominioId`() = runTest(testScheduler) {
-        loadCondominio(Condominio.dummy)
-        viewModel.selectCondominio(Condominio.dummy.id)
-
-        viewModel.onAddApartamentoClick()
-
-        val event = viewModel.uiState.value.navigationEvent
-        assertIs<DashboardNavigationEvent.AddApartamento>(event)
-        assertEquals(Condominio.dummy.id, event.condominioId)
-    }
-
     // --- Stale data / refresh ---
 
     @Test
-    fun `GIVEN condominio selected WHEN loadCondominios called after apartamento added THEN apartamento list is refreshed`() = runTest(testScheduler) {
+    fun `GIVEN apartamentos loaded WHEN loadCondominios called again THEN apartamento list is refreshed`() = runTest(testScheduler) {
         val condominioId = Condominio.dummy.id
         val condominioEmpty = Condominio.dummy.copy(apartamentos = emptyList())
         val newApt = Apartamento.dummy.copy(id = "new-apt", moradores = emptyList())
@@ -240,9 +180,9 @@ class CondominioDashboardViewModelTest : TestsWithMocks() {
         var response = Result.success(listOf(condominioEmpty))
         everySuspending { condominioRepository.getCondominios() } runs { response }
 
+        viewModel.setCondominioId(condominioId)
         viewModel.loadCondominios()
         advanceUntilIdle()
-        viewModel.selectCondominio(condominioId)
         assertEquals(0, viewModel.uiState.value.apartamentos.size)
 
         response = Result.success(listOf(condominioWithApt))
@@ -257,6 +197,7 @@ class CondominioDashboardViewModelTest : TestsWithMocks() {
 
     private suspend fun loadCondominio(condominio: Condominio) {
         everySuspending { condominioRepository.getCondominios() } returns Result.success(listOf(condominio))
+        viewModel.setCondominioId(condominio.id)
         viewModel.loadCondominios()
         testScheduler.advanceUntilIdle()
     }

--- a/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
+++ b/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
@@ -118,9 +118,11 @@ fun AppNavHost(
             AdminHomeScreen(
                 viewModel = adminHomeViewModel,
                 onCondominioClick = { condominioId ->
+                    condominioDashboardViewModel.setCondominioId(condominioId)
                     navController.navigate(CondominioDashboardRoute)
                 },
                 onAddCondominioClick = {
+                    addCondominioViewModel.reset()
                     navController.navigate(AddCondominioRoute)
                 }
             )

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 #Kotlin
 kotlin.code.style=official
+kotlin.native.ignoreDisabledTargets=true
 kotlin.daemon.jvmargs=-Xmx3072M
 
 #Gradle


### PR DESCRIPTION
## Summary
- **Fix stale form state**: `reset()` on AddApartamento/AddCondominio ViewModels prevents instant re-navigation from leftover `createdId`
- **Remove condominio picker**: Dashboard now receives `condominioId` from AdminHome — no more redundant selector
- **Lifecycle-based refresh**: Dashboard and ApartamentoDetail auto-reload on resume (after adding apt/morador)
- **Fix AddMorador pop-back**: Replace fragile triple `popBackStack()` with `popBackStack(AddMoradorRoute, inclusive = true)`
- **Consistent loading pattern**: All screens start with spinner, 1s min delay on first load, silent refresh when data exists
- **Suppress Kotlin/Native warning**: `kotlin.native.ignoreDisabledTargets=true` in gradle.properties

## Test plan
- [ ] Create condominio → tap it → verify dashboard shows with condominio name in top bar
- [ ] Add apartamento → verify return to dashboard with refreshed list (no flicker)
- [ ] Tap apartamento → add morador → verify return to detail with refreshed moradores
- [ ] Re-enter AddCondominio/AddApartamento screens → verify forms are blank (no stale data)
- [ ] Verify 1s loading spinner on first screen entry, no spinner on refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)