### PR TITLE
T5.5: Porteiro assignment management within condominio

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/zalamena/condominios/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/zalamena/condominios/App.kt
@@ -59,6 +59,7 @@ fun App() {
             koinViewModel(),
             koinViewModel(),
             koinViewModel(),
+            koinViewModel(),
             koinViewModel()
         )
     }

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/models/PorteiroInfo.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/models/PorteiroInfo.kt
@@ -1,0 +1,9 @@
+package com.zalamena.condominios.condominio.domain.porteiro.models
+
+data class PorteiroInfo(
+    val id: String,
+    val name: String,
+    val cpf: String,
+    val email: String,
+    val condominioId: String
+)

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/repository/PorteiroDeleter.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/repository/PorteiroDeleter.kt
@@ -1,0 +1,5 @@
+package com.zalamena.condominios.condominio.domain.porteiro.repository
+
+fun interface PorteiroDeleter {
+    suspend fun deletePorteiro(porteiroId: String): Result<Unit>
+}

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/repository/PorteiroProvider.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/repository/PorteiroProvider.kt
@@ -1,0 +1,7 @@
+package com.zalamena.condominios.condominio.domain.porteiro.repository
+
+import com.zalamena.condominios.condominio.domain.porteiro.models.PorteiroInfo
+
+fun interface PorteiroProvider {
+    suspend fun getPorteirosByCondominioId(condominioId: String): Result<List<PorteiroInfo>>
+}

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/repository/PorteiroReassigner.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/repository/PorteiroReassigner.kt
@@ -1,0 +1,5 @@
+package com.zalamena.condominios.condominio.domain.porteiro.repository
+
+fun interface PorteiroReassigner {
+    suspend fun reassignPorteiro(porteiroId: String, newCondominioId: String): Result<Unit>
+}

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/usecase/DeletePorteiroUseCase.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/usecase/DeletePorteiroUseCase.kt
@@ -1,0 +1,15 @@
+package com.zalamena.condominios.condominio.domain.porteiro.usecase
+
+import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroDeleter
+
+class DeletePorteiroUseCase(
+    private val porteiroDeleter: PorteiroDeleter
+) {
+
+    suspend operator fun invoke(porteiroId: String): Result<Unit> {
+        if (porteiroId.isBlank()) {
+            return Result.failure(IllegalArgumentException("porteiroId must not be blank"))
+        }
+        return porteiroDeleter.deletePorteiro(porteiroId)
+    }
+}

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/usecase/GetPorteirosByCondominioUseCase.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/usecase/GetPorteirosByCondominioUseCase.kt
@@ -1,0 +1,16 @@
+package com.zalamena.condominios.condominio.domain.porteiro.usecase
+
+import com.zalamena.condominios.condominio.domain.porteiro.models.PorteiroInfo
+import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroProvider
+
+class GetPorteirosByCondominioUseCase(
+    private val porteiroProvider: PorteiroProvider
+) {
+
+    suspend operator fun invoke(condominioId: String): Result<List<PorteiroInfo>> {
+        if (condominioId.isBlank()) {
+            return Result.failure(IllegalArgumentException("condominioId must not be blank"))
+        }
+        return porteiroProvider.getPorteirosByCondominioId(condominioId)
+    }
+}

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/usecase/ReassignPorteiroUseCase.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/porteiro/usecase/ReassignPorteiroUseCase.kt
@@ -1,0 +1,26 @@
+package com.zalamena.condominios.condominio.domain.porteiro.usecase
+
+import com.zalamena.condominios.condominio.domain.condominio.repository.CondominioRepository
+import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroReassigner
+
+class ReassignPorteiroUseCase(
+    private val porteiroReassigner: PorteiroReassigner,
+    private val condominioRepository: CondominioRepository
+) {
+
+    suspend operator fun invoke(porteiroId: String, newCondominioId: String): Result<Unit> {
+        if (porteiroId.isBlank()) {
+            return Result.failure(IllegalArgumentException("porteiroId must not be blank"))
+        }
+        if (newCondominioId.isBlank()) {
+            return Result.failure(IllegalArgumentException("newCondominioId must not be blank"))
+        }
+
+        val condominioResult = condominioRepository.getCondominio(newCondominioId)
+        if (condominioResult.isFailure) {
+            return Result.failure(IllegalArgumentException("Condominio not found: $newCondominioId"))
+        }
+
+        return porteiroReassigner.reassignPorteiro(porteiroId, newCondominioId)
+    }
+}

--- a/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/porteiro/DeletePorteiroUseCaseTest.kt
+++ b/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/porteiro/DeletePorteiroUseCaseTest.kt
@@ -1,0 +1,59 @@
+package com.zalamena.condominios.condominio.domain.porteiro
+
+import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroDeleter
+import com.zalamena.condominios.condominio.domain.porteiro.usecase.DeletePorteiroUseCase
+import kotlinx.coroutines.test.runTest
+import org.kodein.mock.Mock
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class DeletePorteiroUseCaseTest : TestsWithMocks() {
+
+    @Mock
+    lateinit var porteiroDeleter: PorteiroDeleter
+
+    private val useCase by lazy { DeletePorteiroUseCase(porteiroDeleter) }
+
+    @Test
+    fun `GIVEN valid porteiroId WHEN deleting THEN delegates to deleter`() = runTest {
+        everySuspending { porteiroDeleter.deletePorteiro("p-1") } returns Result.success(Unit)
+
+        val result = useCase("p-1")
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `GIVEN blank porteiroId WHEN deleting THEN returns failure`() = runTest {
+        val result = useCase("")
+
+        assertTrue(result.isFailure)
+        assertIs<IllegalArgumentException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `GIVEN whitespace porteiroId WHEN deleting THEN returns failure`() = runTest {
+        val result = useCase("   ")
+
+        assertTrue(result.isFailure)
+        assertIs<IllegalArgumentException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `GIVEN deleter fails WHEN deleting THEN propagates failure`() = runTest {
+        val exception = Exception("Delete failed")
+        everySuspending { porteiroDeleter.deletePorteiro("p-1") } returns Result.failure(exception)
+
+        val result = useCase("p-1")
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()?.message == "Delete failed")
+    }
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+}

--- a/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/porteiro/GetPorteirosByCondominioUseCaseTest.kt
+++ b/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/porteiro/GetPorteirosByCondominioUseCaseTest.kt
@@ -1,0 +1,76 @@
+package com.zalamena.condominios.condominio.domain.porteiro
+
+import com.zalamena.condominios.condominio.domain.porteiro.models.PorteiroInfo
+import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroProvider
+import com.zalamena.condominios.condominio.domain.porteiro.usecase.GetPorteirosByCondominioUseCase
+import kotlinx.coroutines.test.runTest
+import org.kodein.mock.Mock
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class GetPorteirosByCondominioUseCaseTest : TestsWithMocks() {
+
+    @Mock
+    lateinit var porteiroProvider: PorteiroProvider
+
+    private val useCase by lazy { GetPorteirosByCondominioUseCase(porteiroProvider) }
+
+    @Test
+    fun `GIVEN valid condominioId WHEN getting porteiros THEN returns list from provider`() = runTest {
+        val porteiros = listOf(
+            PorteiroInfo("p-1", "Porteiro 1", "111", "p1@test.com", "condo-1"),
+            PorteiroInfo("p-2", "Porteiro 2", "222", "p2@test.com", "condo-1")
+        )
+        everySuspending { porteiroProvider.getPorteirosByCondominioId("condo-1") } returns Result.success(porteiros)
+
+        val result = useCase("condo-1")
+
+        assertTrue(result.isSuccess)
+        assertEquals(2, result.getOrThrow().size)
+    }
+
+    @Test
+    fun `GIVEN blank condominioId WHEN getting porteiros THEN returns failure`() = runTest {
+        val result = useCase("")
+
+        assertTrue(result.isFailure)
+        assertIs<IllegalArgumentException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `GIVEN whitespace condominioId WHEN getting porteiros THEN returns failure`() = runTest {
+        val result = useCase("   ")
+
+        assertTrue(result.isFailure)
+        assertIs<IllegalArgumentException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `GIVEN provider fails WHEN getting porteiros THEN propagates failure`() = runTest {
+        val exception = Exception("DB error")
+        everySuspending { porteiroProvider.getPorteirosByCondominioId("condo-1") } returns Result.failure(exception)
+
+        val result = useCase("condo-1")
+
+        assertTrue(result.isFailure)
+        assertEquals("DB error", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `GIVEN provider returns empty list WHEN getting porteiros THEN returns empty list`() = runTest {
+        everySuspending { porteiroProvider.getPorteirosByCondominioId("condo-1") } returns Result.success(emptyList())
+
+        val result = useCase("condo-1")
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+}

--- a/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/porteiro/ReassignPorteiroUseCaseTest.kt
+++ b/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/porteiro/ReassignPorteiroUseCaseTest.kt
@@ -1,0 +1,76 @@
+package com.zalamena.condominios.condominio.domain.porteiro
+
+import com.zalamena.condominios.condominio.domain.condominio.models.Condominio
+import com.zalamena.condominios.condominio.domain.condominio.repository.CondominioRepository
+import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroReassigner
+import com.zalamena.condominios.condominio.domain.porteiro.usecase.ReassignPorteiroUseCase
+import kotlinx.coroutines.test.runTest
+import org.kodein.mock.Mock
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ReassignPorteiroUseCaseTest : TestsWithMocks() {
+
+    @Mock
+    lateinit var porteiroReassigner: PorteiroReassigner
+
+    @Mock
+    lateinit var condominioRepository: CondominioRepository
+
+    private val useCase by lazy { ReassignPorteiroUseCase(porteiroReassigner, condominioRepository) }
+
+    @Test
+    fun `GIVEN valid ids and condominio exists WHEN reassigning THEN delegates to reassigner`() = runTest {
+        everySuspending { condominioRepository.getCondominio("condo-2") } returns Result.success(Condominio.dummy)
+        everySuspending { porteiroReassigner.reassignPorteiro("p-1", "condo-2") } returns Result.success(Unit)
+
+        val result = useCase("p-1", "condo-2")
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `GIVEN blank porteiroId WHEN reassigning THEN returns failure`() = runTest {
+        val result = useCase("", "condo-2")
+
+        assertTrue(result.isFailure)
+        assertIs<IllegalArgumentException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `GIVEN blank newCondominioId WHEN reassigning THEN returns failure`() = runTest {
+        val result = useCase("p-1", "")
+
+        assertTrue(result.isFailure)
+        assertIs<IllegalArgumentException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `GIVEN condominio does not exist WHEN reassigning THEN returns failure`() = runTest {
+        everySuspending { condominioRepository.getCondominio("nonexistent") } returns Result.failure(Exception("Not found"))
+
+        val result = useCase("p-1", "nonexistent")
+
+        assertTrue(result.isFailure)
+        assertIs<IllegalArgumentException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `GIVEN reassigner fails WHEN reassigning THEN propagates failure`() = runTest {
+        everySuspending { condominioRepository.getCondominio("condo-2") } returns Result.success(Condominio.dummy)
+        val exception = Exception("Reassign failed")
+        everySuspending { porteiroReassigner.reassignPorteiro("p-1", "condo-2") } returns Result.failure(exception)
+
+        val result = useCase("p-1", "condo-2")
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()?.message == "Reassign failed")
+    }
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+}

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardScreen.kt
@@ -40,7 +40,8 @@ fun CondominioDashboardScreen(
     viewModel: CondominioDashboardViewModel,
     onNavigateToAddApartamento: (condominioId: String) -> Unit = {},
     onNavigateToApartamento: (apartamentoId: String) -> Unit = {},
-    onNavigateToCreatePorteiro: (condominioId: String) -> Unit = {}
+    onNavigateToCreatePorteiro: (condominioId: String) -> Unit = {},
+    onNavigateToPorteiroList: (condominioId: String) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
@@ -69,6 +70,10 @@ fun CondominioDashboardScreen(
                 onNavigateToCreatePorteiro(event.condominioId)
                 viewModel.onNavigationHandled()
             }
+            is DashboardNavigationEvent.PorteiroList -> {
+                onNavigateToPorteiroList(event.condominioId)
+                viewModel.onNavigationHandled()
+            }
             null -> Unit
         }
     }
@@ -89,6 +94,9 @@ fun CondominioDashboardScreen(
                     }
                 },
                 actions = {
+                    Button(onClick = { viewModel.onPorteiroListClick() }) {
+                        Text("Porteiros")
+                    }
                     Button(onClick = { viewModel.onCreatePorteiroClick() }) {
                         Text("Criar Porteiro")
                     }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardViewModel.kt
@@ -25,6 +25,7 @@ sealed class DashboardNavigationEvent {
     data class AddApartamento(val condominioId: String) : DashboardNavigationEvent()
     data class ApartamentoDetails(val apartamentoId: String) : DashboardNavigationEvent()
     data class CreatePorteiro(val condominioId: String) : DashboardNavigationEvent()
+    data class PorteiroList(val condominioId: String) : DashboardNavigationEvent()
 }
 
 class CondominioDashboardViewModel(
@@ -88,6 +89,12 @@ class CondominioDashboardViewModel(
         _uiState.update {
             it.copy(navigationEvent = DashboardNavigationEvent.ApartamentoDetails(apartamentoId))
         }
+    }
+
+    fun onPorteiroListClick() {
+        val condominioId = _uiState.value.condominioId
+        if (condominioId.isBlank()) return
+        _uiState.update { it.copy(navigationEvent = DashboardNavigationEvent.PorteiroList(condominioId)) }
     }
 
     fun onNavigationHandled() {

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/CondominioDashboardNavHost.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/CondominioDashboardNavHost.kt
@@ -12,6 +12,8 @@ import com.zalamena.condominios.condominio.ui.apartamento.detail.ApartamentoDeta
 import com.zalamena.condominios.condominio.ui.apartamento.detail.ApartamentoDetailViewModel
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDashboardScreen
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDashboardViewModel
+import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListScreen
+import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListViewModel
 import com.zalamena.login.ui.createuser.CreateUserViewModel
 import com.zalamena.login.ui.createuser.RoleOption
 import com.zalamena.login.ui.createuser.navigation.CreateUserRoute
@@ -26,13 +28,17 @@ object CondominioDashboardScreenRoute
 @Serializable
 object ApartamentoDetailScreenRoute
 
+@Serializable
+object PorteiroListRoute
+
 fun NavGraphBuilder.condominioDashboardNavHost(
     navController: NavController,
     viewModel: CondominioDashboardViewModel,
     addApartamentoViewModel: AddApartamentoViewModel,
     apartamentoDetailViewModel: ApartamentoDetailViewModel,
     addMoradorFlowViewModel: AddMoradorFlowViewModel,
-    createUserViewModel: CreateUserViewModel
+    createUserViewModel: CreateUserViewModel,
+    porteiroListViewModel: PorteiroListViewModel
 ) {
     navigation<CondominioDashboardRoute>(startDestination = CondominioDashboardScreenRoute) {
         composable<CondominioDashboardScreenRoute> {
@@ -52,6 +58,10 @@ fun NavGraphBuilder.condominioDashboardNavHost(
                     createUserViewModel.setRole(RoleOption.PORTEIRO)
                     createUserViewModel.setCondominioId(condominioId)
                     navController.navigate(CreateUserRoute)
+                },
+                onNavigateToPorteiroList = { condominioId ->
+                    porteiroListViewModel.setCondominioId(condominioId)
+                    navController.navigate(PorteiroListRoute)
                 }
             )
         }
@@ -65,6 +75,10 @@ fun NavGraphBuilder.condominioDashboardNavHost(
                     navController.navigate(AddMoradorRoute)
                 }
             )
+        }
+
+        composable<PorteiroListRoute> {
+            PorteiroListScreen(viewModel = porteiroListViewModel)
         }
     }
 }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/porteiro/list/PorteiroListScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/porteiro/list/PorteiroListScreen.kt
@@ -1,0 +1,243 @@
+package com.zalamena.condominios.condominio.ui.porteiro.list
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.zalamena.condominios.common.ui.components.scaffold.LoadingScaffold
+import com.zalamena.condominios.condominio.ui.apartamento.detail.models.maskCpf
+import com.zalamena.condominios.condominio.ui.condominio.dashboard.models.CondominioSummaryUiData
+import com.zalamena.condominios.condominio.ui.porteiro.list.models.PorteiroUiData
+
+@Composable
+fun PorteiroListScreen(
+    viewModel: PorteiroListViewModel
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.loadPorteiros()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    LoadingScaffold(
+        isLoading = uiState.isLoading,
+        isError = uiState.isError,
+        title = "Porteiros",
+        errorMessage = "Erro ao carregar porteiros"
+    ) {
+        if (uiState.porteiros.isEmpty()) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Text("Nenhum porteiro atribuido a este condominio")
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                item { Spacer(Modifier.height(8.dp)) }
+                items(uiState.porteiros) { porteiro ->
+                    PorteiroCard(
+                        porteiro = porteiro,
+                        onReassignClick = { viewModel.onReassignClick(porteiro) },
+                        onDeleteClick = { viewModel.onDeleteClick(porteiro) }
+                    )
+                }
+            }
+        }
+    }
+
+    uiState.showDeleteConfirmation?.let { porteiro ->
+        DeleteConfirmationDialog(
+            porteiroName = porteiro.name,
+            onConfirm = { viewModel.onConfirmDelete() },
+            onDismiss = { viewModel.onDismissDelete() }
+        )
+    }
+
+    uiState.showReassignDialog?.let { porteiro ->
+        ReassignDialog(
+            porteiroName = porteiro.name,
+            condominios = uiState.availableCondominios,
+            onConfirm = { newCondominioId -> viewModel.onConfirmReassign(newCondominioId) },
+            onDismiss = { viewModel.onDismissReassign() }
+        )
+    }
+}
+
+@Composable
+private fun PorteiroCard(
+    porteiro: PorteiroUiData,
+    onReassignClick: () -> Unit,
+    onDeleteClick: () -> Unit
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(porteiro.name, style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(4.dp))
+            Text("CPF: ${maskCpf(porteiro.cpf)}", style = MaterialTheme.typography.bodyMedium)
+            Spacer(Modifier.height(2.dp))
+            Text(porteiro.email, style = MaterialTheme.typography.bodySmall)
+            Spacer(Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                OutlinedButton(onClick = onReassignClick) {
+                    Text("Reatribuir")
+                }
+                Spacer(Modifier.width(8.dp))
+                Button(
+                    onClick = onDeleteClick,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Text("Excluir")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeleteConfirmationDialog(
+    porteiroName: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Excluir porteiro") },
+        text = { Text("Tem certeza que deseja excluir o porteiro $porteiroName?") },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text("Excluir", color = MaterialTheme.colorScheme.error)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancelar")
+            }
+        }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ReassignDialog(
+    porteiroName: String,
+    condominios: List<CondominioSummaryUiData>,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var selectedCondominioId by remember { mutableStateOf("") }
+    var expanded by remember { mutableStateOf(false) }
+    var selectedLabel by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Reatribuir porteiro") },
+        text = {
+            Column {
+                Text("Selecione o novo condominio para $porteiroName:")
+                Spacer(Modifier.height(12.dp))
+                if (condominios.isEmpty()) {
+                    Text(
+                        "Nenhum outro condominio disponivel",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                } else {
+                    ExposedDropdownMenuBox(
+                        expanded = expanded,
+                        onExpandedChange = { expanded = it }
+                    ) {
+                        OutlinedTextField(
+                            value = selectedLabel,
+                            onValueChange = {},
+                            readOnly = true,
+                            label = { Text("Condominio") },
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                            modifier = Modifier
+                                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                                .fillMaxWidth()
+                        )
+                        ExposedDropdownMenu(
+                            expanded = expanded,
+                            onDismissRequest = { expanded = false }
+                        ) {
+                            condominios.forEach { condominio ->
+                                DropdownMenuItem(
+                                    text = { Text(condominio.nome) },
+                                    onClick = {
+                                        selectedCondominioId = condominio.id
+                                        selectedLabel = condominio.nome
+                                        expanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(selectedCondominioId) },
+                enabled = selectedCondominioId.isNotBlank()
+            ) {
+                Text("Confirmar")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancelar")
+            }
+        }
+    )
+}

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/porteiro/list/PorteiroListViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/porteiro/list/PorteiroListViewModel.kt
@@ -1,0 +1,121 @@
+package com.zalamena.condominios.condominio.ui.porteiro.list
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zalamena.condominios.common.ui.withMinLoading
+import com.zalamena.condominios.condominio.domain.condominio.usecase.GetCondominiosUseCase
+import com.zalamena.condominios.condominio.domain.porteiro.usecase.DeletePorteiroUseCase
+import com.zalamena.condominios.condominio.domain.porteiro.usecase.GetPorteirosByCondominioUseCase
+import com.zalamena.condominios.condominio.domain.porteiro.usecase.ReassignPorteiroUseCase
+import com.zalamena.condominios.condominio.ui.condominio.dashboard.models.CondominioSummaryUiData
+import com.zalamena.condominios.condominio.ui.condominio.dashboard.toSummaryUi
+import com.zalamena.condominios.condominio.ui.porteiro.list.models.PorteiroUiData
+import com.zalamena.condominios.condominio.ui.porteiro.list.models.toUi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class PorteiroListUiState(
+    val condominioId: String = "",
+    val porteiros: List<PorteiroUiData> = emptyList(),
+    val isLoading: Boolean = true,
+    val isError: Boolean = false,
+    val showDeleteConfirmation: PorteiroUiData? = null,
+    val showReassignDialog: PorteiroUiData? = null,
+    val availableCondominios: List<CondominioSummaryUiData> = emptyList()
+)
+
+class PorteiroListViewModel(
+    private val getPorteirosByCondominioUseCase: GetPorteirosByCondominioUseCase,
+    private val deletePorteiroUseCase: DeletePorteiroUseCase,
+    private val reassignPorteiroUseCase: ReassignPorteiroUseCase,
+    private val getCondominiosUseCase: GetCondominiosUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PorteiroListUiState())
+    val uiState: StateFlow<PorteiroListUiState> = _uiState
+
+    fun setCondominioId(condominioId: String) {
+        _uiState.update { it.copy(condominioId = condominioId) }
+    }
+
+    fun loadPorteiros() {
+        val condominioId = _uiState.value.condominioId
+        if (condominioId.isBlank()) return
+
+        viewModelScope.launch {
+            val showSpinner = _uiState.value.porteiros.isEmpty()
+            _uiState.update { it.copy(isLoading = showSpinner, isError = false) }
+
+            val result = withMinLoading(showSpinner) { getPorteirosByCondominioUseCase(condominioId) }
+
+            when {
+                result.isSuccess -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            porteiros = result.getOrThrow().map { info -> info.toUi() }
+                        )
+                    }
+                }
+                result.isFailure -> {
+                    _uiState.update { it.copy(isLoading = false, isError = true) }
+                }
+            }
+        }
+    }
+
+    fun onDeleteClick(porteiro: PorteiroUiData) {
+        _uiState.update { it.copy(showDeleteConfirmation = porteiro) }
+    }
+
+    fun onConfirmDelete() {
+        val porteiro = _uiState.value.showDeleteConfirmation ?: return
+        _uiState.update { it.copy(showDeleteConfirmation = null) }
+
+        viewModelScope.launch {
+            val result = deletePorteiroUseCase(porteiro.id)
+            if (result.isSuccess) {
+                loadPorteiros()
+            }
+        }
+    }
+
+    fun onDismissDelete() {
+        _uiState.update { it.copy(showDeleteConfirmation = null) }
+    }
+
+    fun onReassignClick(porteiro: PorteiroUiData) {
+        viewModelScope.launch {
+            val condominiosResult = getCondominiosUseCase()
+            val condominios = condominiosResult.getOrNull()
+                ?.filter { it.id != _uiState.value.condominioId }
+                ?.map { it.toSummaryUi() }
+                ?: emptyList()
+
+            _uiState.update {
+                it.copy(
+                    showReassignDialog = porteiro,
+                    availableCondominios = condominios
+                )
+            }
+        }
+    }
+
+    fun onConfirmReassign(newCondominioId: String) {
+        val porteiro = _uiState.value.showReassignDialog ?: return
+        _uiState.update { it.copy(showReassignDialog = null) }
+
+        viewModelScope.launch {
+            val result = reassignPorteiroUseCase(porteiro.id, newCondominioId)
+            if (result.isSuccess) {
+                loadPorteiros()
+            }
+        }
+    }
+
+    fun onDismissReassign() {
+        _uiState.update { it.copy(showReassignDialog = null, availableCondominios = emptyList()) }
+    }
+}

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/porteiro/list/models/PorteiroUiData.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/porteiro/list/models/PorteiroUiData.kt
@@ -1,0 +1,17 @@
+package com.zalamena.condominios.condominio.ui.porteiro.list.models
+
+import com.zalamena.condominios.condominio.domain.porteiro.models.PorteiroInfo
+
+data class PorteiroUiData(
+    val id: String,
+    val name: String,
+    val cpf: String,
+    val email: String
+)
+
+fun PorteiroInfo.toUi(): PorteiroUiData = PorteiroUiData(
+    id = id,
+    name = name,
+    cpf = cpf,
+    email = email
+)

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/condominio/CondominioDashboardViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/condominio/CondominioDashboardViewModelTest.kt
@@ -179,6 +179,24 @@ class CondominioDashboardViewModelTest : TestsWithMocks() {
     }
 
     @Test
+    fun `GIVEN condominioId set WHEN onPorteiroListClick THEN emits PorteiroList event with condominioId`() = runTest(testScheduler) {
+        loadCondominio(Condominio.dummy)
+
+        viewModel.onPorteiroListClick()
+
+        val event = viewModel.uiState.value.navigationEvent
+        assertIs<DashboardNavigationEvent.PorteiroList>(event)
+        assertEquals(Condominio.dummy.id, event.condominioId)
+    }
+
+    @Test
+    fun `GIVEN blank condominioId WHEN onPorteiroListClick THEN does not emit event`() = runTest(testScheduler) {
+        viewModel.onPorteiroListClick()
+
+        assertNull(viewModel.uiState.value.navigationEvent)
+    }
+
+    @Test
     fun `GIVEN nav event WHEN handled THEN navigation event is cleared`() = runTest(testScheduler) {
         viewModel.onApartamentoClick("apt-123")
         viewModel.onNavigationHandled()

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/porteiro/PorteiroListViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/porteiro/PorteiroListViewModelTest.kt
@@ -1,0 +1,283 @@
+package com.zalamena.condominios.ui.porteiro
+
+import com.zalamena.condominios.condominio.domain.condominio.models.Condominio
+import com.zalamena.condominios.condominio.domain.condominio.repository.CondominioRepository
+import com.zalamena.condominios.condominio.domain.condominio.usecase.GetCondominiosUseCase
+import com.zalamena.condominios.condominio.domain.porteiro.models.PorteiroInfo
+import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroDeleter
+import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroProvider
+import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroReassigner
+import com.zalamena.condominios.condominio.domain.porteiro.usecase.DeletePorteiroUseCase
+import com.zalamena.condominios.condominio.domain.porteiro.usecase.GetPorteirosByCondominioUseCase
+import com.zalamena.condominios.condominio.domain.porteiro.usecase.ReassignPorteiroUseCase
+import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.kodein.mock.Mock
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PorteiroListViewModelTest : TestsWithMocks() {
+
+    @Mock
+    lateinit var porteiroProvider: PorteiroProvider
+
+    @Mock
+    lateinit var porteiroDeleter: PorteiroDeleter
+
+    @Mock
+    lateinit var porteiroReassigner: PorteiroReassigner
+
+    @Mock
+    lateinit var condominioRepository: CondominioRepository
+
+    private val testScheduler = TestCoroutineScheduler()
+    private val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+
+    private val getPorteirosByCondominioUseCase by lazy { GetPorteirosByCondominioUseCase(porteiroProvider) }
+    private val deletePorteiroUseCase by lazy { DeletePorteiroUseCase(porteiroDeleter) }
+    private val reassignPorteiroUseCase by lazy { ReassignPorteiroUseCase(porteiroReassigner, condominioRepository) }
+    private val getCondominiosUseCase by lazy { GetCondominiosUseCase(condominioRepository) }
+
+    private val viewModel by lazy {
+        PorteiroListViewModel(
+            getPorteirosByCondominioUseCase,
+            deletePorteiroUseCase,
+            reassignPorteiroUseCase,
+            getCondominiosUseCase
+        )
+    }
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // --- Initial state ---
+
+    @Test
+    fun `GIVEN initial state WHEN observing THEN isLoading is true`() = runTest(testScheduler) {
+        assertTrue(viewModel.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `GIVEN initial state WHEN observing THEN porteiros list is empty`() = runTest(testScheduler) {
+        assertEquals(emptyList(), viewModel.uiState.value.porteiros)
+    }
+
+    @Test
+    fun `GIVEN initial state WHEN observing THEN isError is false`() = runTest(testScheduler) {
+        assertFalse(viewModel.uiState.value.isError)
+    }
+
+    @Test
+    fun `GIVEN initial state WHEN observing THEN no dialogs shown`() = runTest(testScheduler) {
+        assertNull(viewModel.uiState.value.showDeleteConfirmation)
+        assertNull(viewModel.uiState.value.showReassignDialog)
+    }
+
+    // --- loadPorteiros ---
+
+    @Test
+    fun `GIVEN condominioId set WHEN loading THEN populates porteiros`() = runTest(testScheduler) {
+        val porteiros = listOf(
+            PorteiroInfo("p-1", "Porteiro 1", "111", "p1@test.com", "condo-1")
+        )
+        everySuspending { porteiroProvider.getPorteirosByCondominioId("condo-1") } returns Result.success(porteiros)
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadPorteiros()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertFalse(state.isError)
+        assertEquals(1, state.porteiros.size)
+        assertEquals("Porteiro 1", state.porteiros.first().name)
+    }
+
+    @Test
+    fun `GIVEN fetch fails WHEN loading THEN sets error state`() = runTest(testScheduler) {
+        everySuspending { porteiroProvider.getPorteirosByCondominioId("condo-1") } returns Result.failure(Exception("error"))
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadPorteiros()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertTrue(state.isError)
+    }
+
+    @Test
+    fun `GIVEN no condominioId WHEN loading THEN does nothing`() = runTest(testScheduler) {
+        viewModel.loadPorteiros()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `GIVEN no porteiros for condominio WHEN loading THEN returns empty list`() = runTest(testScheduler) {
+        everySuspending { porteiroProvider.getPorteirosByCondominioId("condo-1") } returns Result.success(emptyList())
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadPorteiros()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertTrue(state.porteiros.isEmpty())
+    }
+
+    // --- Delete flow ---
+
+    @Test
+    fun `WHEN onDeleteClick THEN showDeleteConfirmation is set`() = runTest(testScheduler) {
+        loadPorteiros()
+
+        val porteiro = viewModel.uiState.value.porteiros.first()
+        viewModel.onDeleteClick(porteiro)
+
+        assertNotNull(viewModel.uiState.value.showDeleteConfirmation)
+        assertEquals(porteiro.id, viewModel.uiState.value.showDeleteConfirmation?.id)
+    }
+
+    @Test
+    fun `WHEN onDismissDelete THEN showDeleteConfirmation is cleared`() = runTest(testScheduler) {
+        loadPorteiros()
+
+        viewModel.onDeleteClick(viewModel.uiState.value.porteiros.first())
+        viewModel.onDismissDelete()
+
+        assertNull(viewModel.uiState.value.showDeleteConfirmation)
+    }
+
+    @Test
+    fun `GIVEN delete succeeds WHEN onConfirmDelete THEN list is refreshed`() = runTest(testScheduler) {
+        val porteiros = listOf(
+            PorteiroInfo("p-1", "Porteiro 1", "11111111111", "p1@test.com", "condo-1")
+        )
+        var providerResponse: Result<List<PorteiroInfo>> = Result.success(porteiros)
+        everySuspending { porteiroProvider.getPorteirosByCondominioId("condo-1") } runs { providerResponse }
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadPorteiros()
+        advanceUntilIdle()
+
+        val porteiro = viewModel.uiState.value.porteiros.first()
+        viewModel.onDeleteClick(porteiro)
+
+        everySuspending { porteiroDeleter.deletePorteiro("p-1") } returns Result.success(Unit)
+        providerResponse = Result.success(emptyList())
+
+        viewModel.onConfirmDelete()
+        advanceUntilIdle()
+
+        assertNull(viewModel.uiState.value.showDeleteConfirmation)
+        assertTrue(viewModel.uiState.value.porteiros.isEmpty())
+    }
+
+    // --- Reassign flow ---
+
+    @Test
+    fun `WHEN onReassignClick THEN showReassignDialog is set and condominios are loaded`() = runTest(testScheduler) {
+        loadPorteiros()
+
+        val otherCondominio = Condominio.dummy.copy(id = "condo-2", nome = "Other")
+        everySuspending { condominioRepository.getCondominios() } returns Result.success(
+            listOf(Condominio.dummy.copy(id = "condo-1"), otherCondominio)
+        )
+
+        val porteiro = viewModel.uiState.value.porteiros.first()
+        viewModel.onReassignClick(porteiro)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertNotNull(state.showReassignDialog)
+        assertEquals(1, state.availableCondominios.size)
+        assertEquals("condo-2", state.availableCondominios.first().id)
+    }
+
+    @Test
+    fun `WHEN onDismissReassign THEN dialog is cleared`() = runTest(testScheduler) {
+        loadPorteiros()
+
+        everySuspending { condominioRepository.getCondominios() } returns Result.success(emptyList())
+
+        viewModel.onReassignClick(viewModel.uiState.value.porteiros.first())
+        advanceUntilIdle()
+
+        viewModel.onDismissReassign()
+
+        assertNull(viewModel.uiState.value.showReassignDialog)
+        assertTrue(viewModel.uiState.value.availableCondominios.isEmpty())
+    }
+
+    @Test
+    fun `GIVEN reassign succeeds WHEN onConfirmReassign THEN list is refreshed`() = runTest(testScheduler) {
+        val porteiros = listOf(
+            PorteiroInfo("p-1", "Porteiro 1", "11111111111", "p1@test.com", "condo-1")
+        )
+        var providerResponse: Result<List<PorteiroInfo>> = Result.success(porteiros)
+        everySuspending { porteiroProvider.getPorteirosByCondominioId("condo-1") } runs { providerResponse }
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadPorteiros()
+        advanceUntilIdle()
+
+        everySuspending { condominioRepository.getCondominios() } returns Result.success(
+            listOf(Condominio.dummy.copy(id = "condo-1"), Condominio.dummy.copy(id = "condo-2"))
+        )
+
+        viewModel.onReassignClick(viewModel.uiState.value.porteiros.first())
+        advanceUntilIdle()
+
+        everySuspending { condominioRepository.getCondominio("condo-2") } returns Result.success(Condominio.dummy.copy(id = "condo-2"))
+        everySuspending { porteiroReassigner.reassignPorteiro("p-1", "condo-2") } returns Result.success(Unit)
+        providerResponse = Result.success(emptyList())
+
+        viewModel.onConfirmReassign("condo-2")
+        advanceUntilIdle()
+
+        assertNull(viewModel.uiState.value.showReassignDialog)
+        assertTrue(viewModel.uiState.value.porteiros.isEmpty())
+    }
+
+    // --- Helpers ---
+
+    private suspend fun loadPorteiros() {
+        val porteiros = listOf(
+            PorteiroInfo("p-1", "Porteiro 1", "11111111111", "p1@test.com", "condo-1")
+        )
+        everySuspending { porteiroProvider.getPorteirosByCondominioId("condo-1") } returns Result.success(porteiros)
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadPorteiros()
+        testScheduler.advanceUntilIdle()
+    }
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+}

--- a/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
+++ b/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
@@ -28,6 +28,15 @@ import com.zalamena.condominios.condominio.ui.addmorador.flowController.AddMorad
 import com.zalamena.condominios.condominio.ui.addmorador.overview.AddMoradorOverviewViewModel
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDashboardViewModel
 import com.zalamena.condominios.condominio.ui.condominio.overview.CondominioOverviewViewModel
+import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListViewModel
+import com.zalamena.condominios.condominio.domain.porteiro.models.PorteiroInfo
+import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroDeleter
+import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroProvider
+import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroReassigner
+import com.zalamena.condominios.condominio.domain.porteiro.usecase.DeletePorteiroUseCase
+import com.zalamena.condominios.condominio.domain.porteiro.usecase.GetPorteirosByCondominioUseCase
+import com.zalamena.condominios.condominio.domain.porteiro.usecase.ReassignPorteiroUseCase
+import com.zalamena.login.domain.models.UserRole
 import com.zalamena.condominios.condominio.ui.moradores.add.AddMoradorViewModel
 import com.zalamena.condominios.condominio.ui.moradores.list.MoradoresListViewModel
 import com.zalamena.condominios.database.AppDatabase
@@ -81,6 +90,31 @@ val repositoryModule = module {
     single<LoginRepository> { LoginRepositoryImpl(get(), get()) }
     single<UserRepository> { UserRepositoryImpl() }
     single<CondominioValidator> { CondominioValidator { id -> get<CondominioRepository>().getCondominio(id).isSuccess } }
+    single<PorteiroProvider> {
+        PorteiroProvider { condominioId ->
+            get<UserRepository>().getUsersByCondominioId(condominioId).map { users ->
+                users.map { user ->
+                    PorteiroInfo(
+                        id = user.id,
+                        name = user.name,
+                        cpf = user.cpf,
+                        email = user.email,
+                        condominioId = (user.role as UserRole.Porteiro).condominioId
+                    )
+                }
+            }
+        }
+    }
+    single<PorteiroDeleter> {
+        PorteiroDeleter { porteiroId ->
+            get<UserRepository>().deleteUser(porteiroId)
+        }
+    }
+    single<PorteiroReassigner> {
+        PorteiroReassigner { porteiroId, newCondominioId ->
+            get<UserRepository>().updateUserRole(porteiroId, UserRole.Porteiro(newCondominioId))
+        }
+    }
 }
 
 val useCaseModule = module {
@@ -98,6 +132,9 @@ val useCaseModule = module {
     factory<AddMoradorUseCase> { AddMoradorUseCaseImpl(get()) }
     factory { GetMoradoresForApartamentoUseCase(get()) }
     factory { CreateUserUseCase(get(), get()) }
+    factory { GetPorteirosByCondominioUseCase(get()) }
+    factory { DeletePorteiroUseCase(get()) }
+    factory { ReassignPorteiroUseCase(get(), get()) }
 }
 
 val viewModelModule = module {
@@ -115,4 +152,5 @@ val viewModelModule = module {
     viewModelOf(::LoginViewModel)
     viewModelOf(::SplashViewModel)
     viewModelOf(::CreateUserViewModel)
+    viewModelOf(::PorteiroListViewModel)
 }

--- a/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/mapper/LoginMapper.kt
+++ b/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/mapper/LoginMapper.kt
@@ -12,6 +12,7 @@ fun UserDto.toDomain(): User {
         else -> throw IllegalArgumentException("Unknown role: $role")
     }
     return User(
+        id = "",
         name = username,
         cpf = cpf,
         email = email,

--- a/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/repository/UserRepositoryImpl.kt
+++ b/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/repository/UserRepositoryImpl.kt
@@ -3,7 +3,10 @@ package com.zalamena.login.data.repository
 import com.zalamena.login.domain.models.User
 import com.zalamena.login.domain.models.UserRole
 import com.zalamena.login.domain.repository.UserRepository
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
+@OptIn(ExperimentalUuidApi::class)
 class UserRepositoryImpl : UserRepository {
 
     private val users = mutableListOf<User>()
@@ -16,6 +19,7 @@ class UserRepositoryImpl : UserRepository {
     ): Result<User> {
         return try {
             val user = User(
+                id = Uuid.random().toString(),
                 name = name,
                 cpf = cpf,
                 email = email,
@@ -30,5 +34,44 @@ class UserRepositoryImpl : UserRepository {
 
     override suspend fun getUsers(): Result<List<User>> {
         return Result.success(users.toList())
+    }
+
+    override suspend fun getUsersByCondominioId(condominioId: String): Result<List<User>> {
+        return try {
+            val filtered = users.filter { user ->
+                val role = user.role
+                role is UserRole.Porteiro && role.condominioId == condominioId
+            }
+            Result.success(filtered)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun deleteUser(userId: String): Result<Unit> {
+        return try {
+            val removed = users.removeAll { it.id == userId }
+            if (removed) {
+                Result.success(Unit)
+            } else {
+                Result.failure(NoSuchElementException("User not found: $userId"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun updateUserRole(userId: String, newRole: UserRole): Result<Unit> {
+        return try {
+            val index = users.indexOfFirst { it.id == userId }
+            if (index == -1) {
+                Result.failure(NoSuchElementException("User not found: $userId"))
+            } else {
+                users[index] = users[index].copy(role = newRole)
+                Result.success(Unit)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 }

--- a/features/login/data/src/commonTest/kotlin/com/zalamena/login/data/repository/UserRepositoryTest.kt
+++ b/features/login/data/src/commonTest/kotlin/com/zalamena/login/data/repository/UserRepositoryTest.kt
@@ -12,12 +12,13 @@ class UserRepositoryTest {
     private val repository = UserRepositoryImpl()
 
     @Test
-    fun `GIVEN valid admin data WHEN createUser THEN returns success with user`() = runTest {
+    fun `GIVEN valid admin data WHEN createUser THEN returns success with user and generated id`() = runTest {
         val role = UserRole.Admin
         val result = repository.createUser("Admin", "12345678900", "admin@test.com", role)
 
         assertTrue(result.isSuccess)
         val user = result.getOrThrow()
+        assertTrue(user.id.isNotBlank())
         assertEquals("Admin", user.name)
         assertEquals("12345678900", user.cpf)
         assertEquals("admin@test.com", user.email)
@@ -31,6 +32,7 @@ class UserRepositoryTest {
 
         assertTrue(result.isSuccess)
         val user = result.getOrThrow()
+        assertTrue(user.id.isNotBlank())
         assertEquals("Porteiro", user.name)
         val userRole = user.role
         assertIs<UserRole.Porteiro>(userRole)
@@ -54,5 +56,113 @@ class UserRepositoryTest {
 
         assertTrue(result.isSuccess)
         assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    @Test
+    fun `GIVEN two users created THEN each has a unique id`() = runTest {
+        val user1 = repository.createUser("A", "111", "a@test.com", UserRole.Admin).getOrThrow()
+        val user2 = repository.createUser("B", "222", "b@test.com", UserRole.Admin).getOrThrow()
+
+        assertTrue(user1.id != user2.id)
+    }
+
+    // --- getUsersByCondominioId ---
+
+    @Test
+    fun `GIVEN porteiros in different condominios WHEN getUsersByCondominioId THEN returns only matching`() = runTest {
+        repository.createUser("P1", "111", "p1@test.com", UserRole.Porteiro("condo-1"))
+        repository.createUser("P2", "222", "p2@test.com", UserRole.Porteiro("condo-2"))
+        repository.createUser("P3", "333", "p3@test.com", UserRole.Porteiro("condo-1"))
+
+        val result = repository.getUsersByCondominioId("condo-1")
+
+        assertTrue(result.isSuccess)
+        assertEquals(2, result.getOrThrow().size)
+        assertTrue(result.getOrThrow().all { (it.role as UserRole.Porteiro).condominioId == "condo-1" })
+    }
+
+    @Test
+    fun `GIVEN admin users WHEN getUsersByCondominioId THEN returns empty list`() = runTest {
+        repository.createUser("Admin", "111", "a@test.com", UserRole.Admin)
+
+        val result = repository.getUsersByCondominioId("condo-1")
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    @Test
+    fun `GIVEN no users WHEN getUsersByCondominioId THEN returns empty list`() = runTest {
+        val result = repository.getUsersByCondominioId("condo-1")
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    // --- deleteUser ---
+
+    @Test
+    fun `GIVEN user exists WHEN deleteUser THEN user is removed`() = runTest {
+        val user = repository.createUser("Admin", "111", "a@test.com", UserRole.Admin).getOrThrow()
+
+        val result = repository.deleteUser(user.id)
+
+        assertTrue(result.isSuccess)
+        assertEquals(0, repository.getUsers().getOrThrow().size)
+    }
+
+    @Test
+    fun `GIVEN user does not exist WHEN deleteUser THEN returns failure`() = runTest {
+        val result = repository.deleteUser("nonexistent-id")
+
+        assertTrue(result.isFailure)
+        assertIs<NoSuchElementException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `GIVEN multiple users WHEN deleteUser THEN only target is removed`() = runTest {
+        val user1 = repository.createUser("A", "111", "a@test.com", UserRole.Admin).getOrThrow()
+        repository.createUser("B", "222", "b@test.com", UserRole.Admin)
+
+        repository.deleteUser(user1.id)
+
+        val remaining = repository.getUsers().getOrThrow()
+        assertEquals(1, remaining.size)
+        assertEquals("B", remaining.first().name)
+    }
+
+    // --- updateUserRole ---
+
+    @Test
+    fun `GIVEN user exists WHEN updateUserRole THEN role is updated`() = runTest {
+        val user = repository.createUser("P", "111", "p@test.com", UserRole.Porteiro("condo-1")).getOrThrow()
+
+        val result = repository.updateUserRole(user.id, UserRole.Porteiro("condo-2"))
+
+        assertTrue(result.isSuccess)
+        val updated = repository.getUsers().getOrThrow().first { it.id == user.id }
+        val role = updated.role
+        assertIs<UserRole.Porteiro>(role)
+        assertEquals("condo-2", role.condominioId)
+    }
+
+    @Test
+    fun `GIVEN user does not exist WHEN updateUserRole THEN returns failure`() = runTest {
+        val result = repository.updateUserRole("nonexistent-id", UserRole.Admin)
+
+        assertTrue(result.isFailure)
+        assertIs<NoSuchElementException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `GIVEN user exists WHEN updateUserRole THEN other fields are preserved`() = runTest {
+        val user = repository.createUser("P", "111", "p@test.com", UserRole.Porteiro("condo-1")).getOrThrow()
+
+        repository.updateUserRole(user.id, UserRole.Porteiro("condo-2"))
+
+        val updated = repository.getUsers().getOrThrow().first { it.id == user.id }
+        assertEquals("P", updated.name)
+        assertEquals("111", updated.cpf)
+        assertEquals("p@test.com", updated.email)
     }
 }

--- a/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/models/User.kt
+++ b/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/models/User.kt
@@ -1,6 +1,7 @@
 package com.zalamena.login.domain.models
 
 data class User(
+    val id: String,
     val name: String,
     val cpf: String,
     val email: String,

--- a/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/repository/UserRepository.kt
+++ b/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/repository/UserRepository.kt
@@ -13,4 +13,10 @@ interface UserRepository {
     ): Result<User>
 
     suspend fun getUsers(): Result<List<User>>
+
+    suspend fun getUsersByCondominioId(condominioId: String): Result<List<User>>
+
+    suspend fun deleteUser(userId: String): Result<Unit>
+
+    suspend fun updateUserRole(userId: String, newRole: UserRole): Result<Unit>
 }

--- a/features/login/domain/src/commonTest/kotlin/com/zalamena/login/domain/usecase/CreateUserUseCaseTest.kt
+++ b/features/login/domain/src/commonTest/kotlin/com/zalamena/login/domain/usecase/CreateUserUseCaseTest.kt
@@ -30,7 +30,7 @@ class CreateUserUseCaseTest : TestsWithMocks() {
     @Test
     fun `GIVEN valid admin data WHEN creating user THEN returns success`() = runTest {
         val role = UserRole.Admin
-        val user = User(name = "Admin", cpf = "12345678900", email = "admin@test.com", role = role)
+        val user = User(id = "user-1", name = "Admin", cpf = "12345678900", email = "admin@test.com", role = role)
         everySuspending { userRepository.createUser("Admin", "12345678900", "admin@test.com", role) } returns Result.success(user)
 
         val result = useCase("Admin", "12345678900", "admin@test.com", role)
@@ -43,7 +43,7 @@ class CreateUserUseCaseTest : TestsWithMocks() {
     @Test
     fun `GIVEN valid porteiro data WHEN creating user THEN returns success`() = runTest {
         val role = UserRole.Porteiro("condo-1")
-        val user = User(name = "Porteiro", cpf = "11111111111", email = "porteiro@test.com", role = role)
+        val user = User(id = "user-2", name = "Porteiro", cpf = "11111111111", email = "porteiro@test.com", role = role)
         everySuspending { condominioValidator.exists("condo-1") } returns true
         everySuspending { userRepository.createUser("Porteiro", "11111111111", "porteiro@test.com", role) } returns Result.success(user)
 
@@ -101,7 +101,7 @@ class CreateUserUseCaseTest : TestsWithMocks() {
     @Test
     fun `GIVEN name with whitespace WHEN creating user THEN name is trimmed`() = runTest {
         val role = UserRole.Admin
-        val user = User(name = "Admin", cpf = "12345678900", email = "admin@test.com", role = role)
+        val user = User(id = "user-3", name = "Admin", cpf = "12345678900", email = "admin@test.com", role = role)
         everySuspending { userRepository.createUser("Admin", "12345678900", "admin@test.com", role) } returns Result.success(user)
 
         val result = useCase("  Admin  ", "  12345678900  ", "  admin@test.com  ", role)

--- a/features/login/domain/src/commonTest/kotlin/com/zalamena/login/domain/usecase/LoginUseCaseTest.kt
+++ b/features/login/domain/src/commonTest/kotlin/com/zalamena/login/domain/usecase/LoginUseCaseTest.kt
@@ -31,6 +31,7 @@ class LoginUseCaseTest: TestsWithMocks() {
         val email = "email"
 
         everySuspending { loginRepository.login(username, password) } returns Result.success(User(
+            id = "user-1",
             name = username,
             cpf = cpf,
             email = email,

--- a/features/login/ui/src/commonTest/kotlin/com/zalamena/login/ui/LoginViewModelTest.kt
+++ b/features/login/ui/src/commonTest/kotlin/com/zalamena/login/ui/LoginViewModelTest.kt
@@ -73,7 +73,7 @@ class LoginViewModelTest : TestsWithMocks() {
 
     @Test
     fun `GIVEN admin login succeeds THEN navigationEvent is NavigateToAdminHome and isLoading is false`() = runTest {
-        val user = User(name = "Admin", cpf = "00000000000", email = "admin@test.com", role = UserRole.Admin)
+        val user = User(id = "user-1", name = "Admin", cpf = "00000000000", email = "admin@test.com", role = UserRole.Admin)
         everySuspending { loginRepository.login(isAny(), isAny()) } returns Result.success(user)
 
         viewModel.setUsername("admin")
@@ -89,7 +89,7 @@ class LoginViewModelTest : TestsWithMocks() {
 
     @Test
     fun `GIVEN porteiro login succeeds THEN navigationEvent is NavigateToDoormanHome`() = runTest {
-        val user = User(name = "Porteiro", cpf = "11111111111", email = "porteiro@test.com", role = UserRole.Porteiro("condo-1"))
+        val user = User(id = "user-2", name = "Porteiro", cpf = "11111111111", email = "porteiro@test.com", role = UserRole.Porteiro("condo-1"))
         everySuspending { loginRepository.login(isAny(), isAny()) } returns Result.success(user)
 
         viewModel.setUsername("porteiro")
@@ -133,7 +133,7 @@ class LoginViewModelTest : TestsWithMocks() {
 
     @Test
     fun `GIVEN onNavigationHandled called after success THEN navigationEvent is cleared`() = runTest {
-        val user = User(name = "Admin", cpf = "00000000000", email = "admin@test.com", role = UserRole.Admin)
+        val user = User(id = "user-1", name = "Admin", cpf = "00000000000", email = "admin@test.com", role = UserRole.Admin)
         everySuspending { loginRepository.login(isAny(), isAny()) } returns Result.success(user)
 
         viewModel.setUsername("admin")

--- a/features/login/ui/src/commonTest/kotlin/com/zalamena/login/ui/createuser/CreateUserViewModelTest.kt
+++ b/features/login/ui/src/commonTest/kotlin/com/zalamena/login/ui/createuser/CreateUserViewModelTest.kt
@@ -102,7 +102,7 @@ class CreateUserViewModelTest : TestsWithMocks() {
     @Test
     fun `GIVEN valid porteiro data WHEN createUser THEN generatedPassword is set`() = runTest {
         val role = UserRole.Porteiro("condo-1")
-        val user = User(name = "Porteiro", cpf = "11111111111", email = "p@test.com", role = role)
+        val user = User(id = "user-1", name = "Porteiro", cpf = "11111111111", email = "p@test.com", role = role)
         everySuspending { condominioValidator.exists("condo-1") } returns true
         everySuspending { userRepository.createUser("Porteiro", "11111111111", "p@test.com", role) } returns Result.success(user)
 
@@ -124,7 +124,7 @@ class CreateUserViewModelTest : TestsWithMocks() {
     @Test
     fun `GIVEN valid admin data WHEN createUser THEN generatedPassword is set`() = runTest {
         val role = UserRole.Admin
-        val user = User(name = "Admin", cpf = "12345678900", email = "a@test.com", role = role)
+        val user = User(id = "user-2", name = "Admin", cpf = "12345678900", email = "a@test.com", role = role)
         everySuspending { userRepository.createUser("Admin", "12345678900", "a@test.com", role) } returns Result.success(user)
 
         viewModel.setName("Admin")

--- a/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
+++ b/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
@@ -32,6 +32,7 @@ import com.zalamena.condominios.condominio.ui.addmorador.overview.AddMoradorOver
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDashboardViewModel
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.CondominioDashboardRoute
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.condominioDashboardNavHost
+import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListViewModel
 import com.zalamena.condominios.pessoa.ui.addpessoa.AddPessoaViewModel
 import com.zalamena.login.domain.models.UserRole
 import com.zalamena.login.ui.LoginViewModel
@@ -70,7 +71,8 @@ fun AppNavHost(
     apartamentoDetailViewModel: ApartamentoDetailViewModel,
     loginViewModel: LoginViewModel,
     adminHomeViewModel: AdminHomeViewModel,
-    createUserViewModel: CreateUserViewModel
+    createUserViewModel: CreateUserViewModel,
+    porteiroListViewModel: PorteiroListViewModel
 ) {
     NavHost(navController, startDestination = SplashRoute) {
 
@@ -178,7 +180,8 @@ fun AppNavHost(
             addApartamentoViewModel,
             apartamentoDetailViewModel,
             addMoradorFlowViewModel,
-            createUserViewModel
+            createUserViewModel,
+            porteiroListViewModel
         )
 
         addCondominioNavHost(


### PR DESCRIPTION
## Summary
- Admin can view, reassign, and delete porteiros assigned to a condominio
- Navigable from Condominio Dashboard via "Porteiros" button
- Delete shows confirmation dialog; reassign shows dropdown of other condominios
- Decoupled architecture: `PorteiroProvider`, `PorteiroDeleter`, `PorteiroReassigner` functional interfaces in `condominio:domain` — no cross-module domain coupling
- `User` model now has a generated UUID `id` field

## Test plan
- [x] Navigate to a condominio dashboard, tap "Porteiros"
- [x] Verify empty state when no porteiros assigned
- [x] Create a porteiro for the condominio, verify it appears in the list
- [x] Reassign a porteiro to a different condominio — verify it disappears from current list
- [x] Delete a porteiro — verify confirmation dialog and removal

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)