### PR TITLE
T7 · Doorman morador search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,10 @@ powershell.exe -Command "Set-Location 'C:\Users\franc\Documents\Projetos Android
 
 > **Note:** `org.gradle.java.home` is set in `local.properties` to use OpenJDK 25 (`~/.jdks/openjdk-25`). Gradle 9 requires JVM 17+; the system default is JDK 8.
 
+## Workflow
+
+- **Always use the dev agent** (`subagent_type: dev`) for implementing features, writing code, running builds, and running tests. Only do quick reads/exploration in the main conversation to gather context for the agent prompt.
+
 ## Key conventions
 
 - **CPF masking** is a UI concern — domain stores CPF as plain string; `maskCpf()` lives in the UI layer

--- a/composeApp/src/commonMain/kotlin/com/zalamena/condominios/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/zalamena/condominios/App.kt
@@ -68,6 +68,7 @@ fun App() {
             koinViewModel(),
             koinViewModel(),
             koinViewModel(),
+            koinViewModel(),
             onLogout = { logoutUseCase() }
         )
     }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardScreen.kt
@@ -42,6 +42,7 @@ fun CondominioDashboardScreen(
     onNavigateToApartamento: (apartamentoId: String) -> Unit = {},
     onNavigateToCreatePorteiro: (condominioId: String) -> Unit = {},
     onNavigateToPorteiroList: (condominioId: String) -> Unit = {},
+    onNavigateToSearchMorador: (condominioId: String) -> Unit = {},
     onLogout: () -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -73,6 +74,10 @@ fun CondominioDashboardScreen(
             }
             is DashboardNavigationEvent.PorteiroList -> {
                 onNavigateToPorteiroList(event.condominioId)
+                viewModel.onNavigationHandled()
+            }
+            is DashboardNavigationEvent.SearchMorador -> {
+                onNavigateToSearchMorador(event.condominioId)
                 viewModel.onNavigationHandled()
             }
             is DashboardNavigationEvent.Logout -> {
@@ -107,6 +112,9 @@ fun CondominioDashboardScreen(
                             Text("Criar Porteiro")
                         }
                     } else {
+                        Button(onClick = { viewModel.onSearchMoradorClick() }) {
+                            Text("Buscar Morador")
+                        }
                         Button(onClick = onLogout) {
                             Text("Sair")
                         }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardViewModel.kt
@@ -27,6 +27,7 @@ sealed class DashboardNavigationEvent {
     data class ApartamentoDetails(val apartamentoId: String) : DashboardNavigationEvent()
     data class CreatePorteiro(val condominioId: String) : DashboardNavigationEvent()
     data class PorteiroList(val condominioId: String) : DashboardNavigationEvent()
+    data class SearchMorador(val condominioId: String) : DashboardNavigationEvent()
     object Logout : DashboardNavigationEvent()
 }
 
@@ -105,6 +106,12 @@ class CondominioDashboardViewModel(
         val condominioId = _uiState.value.condominioId
         if (condominioId.isBlank()) return
         _uiState.update { it.copy(navigationEvent = DashboardNavigationEvent.PorteiroList(condominioId)) }
+    }
+
+    fun onSearchMoradorClick() {
+        val condominioId = _uiState.value.condominioId
+        if (condominioId.isBlank()) return
+        _uiState.update { it.copy(navigationEvent = DashboardNavigationEvent.SearchMorador(condominioId)) }
     }
 
     fun onNavigationHandled() {

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/DoormanDashboardNavHost.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/DoormanDashboardNavHost.kt
@@ -5,18 +5,40 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.zalamena.condominios.condominio.ui.apartamento.detail.ApartamentoDetailScreen
 import com.zalamena.condominios.condominio.ui.apartamento.detail.ApartamentoDetailViewModel
+import com.zalamena.condominios.condominio.ui.moradores.search.MoradorSearchScreen
+import com.zalamena.condominios.condominio.ui.moradores.search.MoradorSearchViewModel
 import kotlinx.serialization.Serializable
 
 @Serializable
 object DoormanApartamentoDetailRoute
 
+@Serializable
+object DoormanMoradorSearchRoute
+
 fun NavGraphBuilder.doormanApartamentoDetail(
+    navController: NavController,
     apartamentoDetailViewModel: ApartamentoDetailViewModel
 ) {
     composable<DoormanApartamentoDetailRoute> {
         ApartamentoDetailScreen(
             viewModel = apartamentoDetailViewModel,
             isAdminMode = false
+        )
+    }
+}
+
+fun NavGraphBuilder.doormanMoradorSearch(
+    navController: NavController,
+    moradorSearchViewModel: MoradorSearchViewModel,
+    apartamentoDetailViewModel: ApartamentoDetailViewModel
+) {
+    composable<DoormanMoradorSearchRoute> {
+        MoradorSearchScreen(
+            viewModel = moradorSearchViewModel,
+            onNavigateToApartamento = { apartamentoId ->
+                apartamentoDetailViewModel.setApartamentoId(apartamentoId)
+                navController.navigate(DoormanApartamentoDetailRoute)
+            }
         )
     }
 }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/search/MoradorSearchScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/search/MoradorSearchScreen.kt
@@ -1,0 +1,134 @@
+package com.zalamena.condominios.condominio.ui.moradores.search
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MoradorSearchScreen(
+    viewModel: MoradorSearchViewModel,
+    onNavigateToApartamento: (apartamentoId: String) -> Unit = {}
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadMoradores()
+    }
+
+    LaunchedEffect(uiState.navigationEvent) {
+        when (val event = uiState.navigationEvent) {
+            is MoradorSearchNavigationEvent.ApartamentoDetails -> {
+                onNavigateToApartamento(event.apartamentoId)
+                viewModel.onNavigationHandled()
+            }
+            null -> Unit
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Buscar Morador") })
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(padding).padding(horizontal = 16.dp)
+        ) {
+            OutlinedTextField(
+                value = uiState.query,
+                onValueChange = viewModel::setQuery,
+                label = { Text("Nome ou apartamento") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Box(modifier = Modifier.fillMaxSize()) {
+                when {
+                    uiState.isLoading -> {
+                        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                    }
+                    uiState.isError -> {
+                        Text(
+                            text = "Erro ao carregar moradores",
+                            modifier = Modifier.align(Alignment.Center)
+                        )
+                    }
+                    uiState.moradores.isEmpty() && uiState.query.isNotBlank() -> {
+                        Text(
+                            text = "Nenhum morador encontrado",
+                            modifier = Modifier.align(Alignment.Center),
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                    }
+                    uiState.moradores.isEmpty() -> {
+                        Text(
+                            text = "Nenhum morador cadastrado",
+                            modifier = Modifier.align(Alignment.Center),
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                    }
+                    else -> {
+                        LazyColumn(
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            items(uiState.moradores) { morador ->
+                                MoradorSearchCard(
+                                    morador = morador,
+                                    onClick = { viewModel.onMoradorClick(morador.apartamentoId) }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MoradorSearchCard(morador: MoradorSearchUiData, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column {
+                Text(morador.nome, style = MaterialTheme.typography.titleMedium)
+                Text(morador.tipoLabel, style = MaterialTheme.typography.bodySmall)
+                Text(morador.maskedCpf, style = MaterialTheme.typography.bodySmall)
+            }
+            Column(horizontalAlignment = Alignment.End) {
+                Text("Apt ${morador.aptNumero}", style = MaterialTheme.typography.titleSmall)
+                Text("Andar ${morador.aptAndar}", style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/search/MoradorSearchViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/search/MoradorSearchViewModel.kt
@@ -1,0 +1,113 @@
+package com.zalamena.condominios.condominio.ui.moradores.search
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zalamena.condominios.condominio.domain.condominio.usecase.GetMoradoresUseCase
+import com.zalamena.condominios.condominio.domain.morador.model.Morador
+import com.zalamena.condominios.condominio.ui.apartamento.detail.models.maskCpf
+import com.zalamena.condominios.condominio.ui.apartamento.detail.models.toLabel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class MoradorSearchUiData(
+    val nome: String,
+    val maskedCpf: String,
+    val tipoLabel: String,
+    val aptNumero: String,
+    val aptAndar: String,
+    val apartamentoId: String
+)
+
+data class MoradorSearchUiState(
+    val query: String = "",
+    val moradores: List<MoradorSearchUiData> = emptyList(),
+    val isLoading: Boolean = false,
+    val isError: Boolean = false,
+    val navigationEvent: MoradorSearchNavigationEvent? = null
+)
+
+sealed class MoradorSearchNavigationEvent {
+    data class ApartamentoDetails(val apartamentoId: String) : MoradorSearchNavigationEvent()
+}
+
+class MoradorSearchViewModel(
+    private val getMoradoresUseCase: GetMoradoresUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(MoradorSearchUiState())
+    val uiState: StateFlow<MoradorSearchUiState> = _uiState
+
+    private var allMoradores: List<Morador> = emptyList()
+    private var condominioId: String = ""
+
+    fun setCondominioId(id: String) {
+        condominioId = id
+    }
+
+    fun loadMoradores() {
+        if (condominioId.isBlank()) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, isError = false) }
+
+            val result = getMoradoresUseCase(condominioId)
+
+            result
+                .onSuccess { moradores ->
+                    allMoradores = moradores
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            moradores = filterAndMap(moradores, it.query)
+                        )
+                    }
+                }
+                .onFailure {
+                    _uiState.update { it.copy(isLoading = false, isError = true) }
+                }
+        }
+    }
+
+    fun setQuery(query: String) {
+        _uiState.update {
+            it.copy(
+                query = query,
+                moradores = filterAndMap(allMoradores, query)
+            )
+        }
+    }
+
+    fun onMoradorClick(apartamentoId: String) {
+        _uiState.update {
+            it.copy(navigationEvent = MoradorSearchNavigationEvent.ApartamentoDetails(apartamentoId))
+        }
+    }
+
+    fun onNavigationHandled() {
+        _uiState.update { it.copy(navigationEvent = null) }
+    }
+
+    private fun filterAndMap(moradores: List<Morador>, query: String): List<MoradorSearchUiData> {
+        val filtered = if (query.isBlank()) {
+            moradores
+        } else {
+            val lowerQuery = query.lowercase()
+            moradores.filter { morador ->
+                morador.nome.lowercase().contains(lowerQuery) ||
+                    morador.apartamento.numero.lowercase().contains(lowerQuery)
+            }
+        }
+        return filtered.map { it.toSearchUiData() }
+    }
+
+    private fun Morador.toSearchUiData() = MoradorSearchUiData(
+        nome = nome,
+        maskedCpf = maskCpf(cpf),
+        tipoLabel = tipo.toLabel(),
+        aptNumero = apartamento.numero,
+        aptAndar = apartamento.andar,
+        apartamentoId = apartamento.id
+    )
+}

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/condominio/CondominioDashboardViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/condominio/CondominioDashboardViewModelTest.kt
@@ -197,6 +197,24 @@ class CondominioDashboardViewModelTest : TestsWithMocks() {
     }
 
     @Test
+    fun `GIVEN condominioId set WHEN onSearchMoradorClick THEN emits SearchMorador event with condominioId`() = runTest(testScheduler) {
+        loadCondominio(Condominio.dummy)
+
+        viewModel.onSearchMoradorClick()
+
+        val event = viewModel.uiState.value.navigationEvent
+        assertIs<DashboardNavigationEvent.SearchMorador>(event)
+        assertEquals(Condominio.dummy.id, event.condominioId)
+    }
+
+    @Test
+    fun `GIVEN blank condominioId WHEN onSearchMoradorClick THEN does not emit event`() = runTest(testScheduler) {
+        viewModel.onSearchMoradorClick()
+
+        assertNull(viewModel.uiState.value.navigationEvent)
+    }
+
+    @Test
     fun `GIVEN nav event WHEN handled THEN navigation event is cleared`() = runTest(testScheduler) {
         viewModel.onApartamentoClick("apt-123")
         viewModel.onNavigationHandled()

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/moradores/MoradorSearchViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/moradores/MoradorSearchViewModelTest.kt
@@ -1,0 +1,235 @@
+package com.zalamena.condominios.ui.moradores
+
+import com.zalamena.condominios.condominio.domain.apartamento.models.Apartamento
+import com.zalamena.condominios.condominio.domain.morador.model.Morador
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
+import com.zalamena.condominios.condominio.domain.condominio.usecase.GetMoradoresUseCase
+import com.zalamena.condominios.condominio.ui.moradores.search.MoradorSearchViewModel
+import com.zalamena.condominios.condominio.ui.moradores.search.MoradorSearchNavigationEvent
+import com.zalamena.condominios.pessoa.domain.models.Pessoa
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.kodein.mock.Mock
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MoradorSearchViewModelTest : TestsWithMocks() {
+
+    @Mock
+    lateinit var moradoresRepository: MoradoresRepository
+
+    private val testScheduler = TestCoroutineScheduler()
+    private val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+
+    private val getMoradoresUseCase by lazy { GetMoradoresUseCase(moradoresRepository) }
+    private val viewModel by lazy { MoradorSearchViewModel(getMoradoresUseCase) }
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+
+    // --- Initial state ---
+
+    @Test
+    fun `GIVEN initial state WHEN observing THEN query is empty`() = runTest(testScheduler) {
+        assertEquals("", viewModel.uiState.value.query)
+    }
+
+    @Test
+    fun `GIVEN initial state WHEN observing THEN moradores list is empty`() = runTest(testScheduler) {
+        assertEquals(emptyList(), viewModel.uiState.value.moradores)
+    }
+
+    @Test
+    fun `GIVEN initial state WHEN observing THEN isLoading is false`() = runTest(testScheduler) {
+        assertFalse(viewModel.uiState.value.isLoading)
+    }
+
+    // --- Load moradores ---
+
+    @Test
+    fun `GIVEN condominioId set WHEN loadMoradores THEN moradores are loaded`() = runTest(testScheduler) {
+        loadMoradores(listOf(makeMorador("João", "101")))
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertFalse(state.isError)
+        assertEquals(1, state.moradores.size)
+    }
+
+    @Test
+    fun `GIVEN fetch fails WHEN loadMoradores THEN sets error state`() = runTest(testScheduler) {
+        everySuspending { moradoresRepository.getMoradoresForCondominio("condo-1") } returns Result.failure(Exception("DB error"))
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadMoradores()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isError)
+    }
+
+    @Test
+    fun `GIVEN blank condominioId WHEN loadMoradores THEN does nothing`() = runTest(testScheduler) {
+        viewModel.loadMoradores()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isLoading)
+        assertTrue(viewModel.uiState.value.moradores.isEmpty())
+    }
+
+    // --- Search by name ---
+
+    @Test
+    fun `GIVEN moradores loaded WHEN query matches name THEN filters results`() = runTest(testScheduler) {
+        loadMoradores(listOf(
+            makeMorador("João Silva", "101"),
+            makeMorador("Maria Santos", "102"),
+            makeMorador("João Pedro", "103")
+        ))
+
+        viewModel.setQuery("João")
+
+        assertEquals(2, viewModel.uiState.value.moradores.size)
+    }
+
+    @Test
+    fun `GIVEN moradores loaded WHEN query matches name case insensitive THEN filters results`() = runTest(testScheduler) {
+        loadMoradores(listOf(
+            makeMorador("João Silva", "101"),
+            makeMorador("Maria Santos", "102")
+        ))
+
+        viewModel.setQuery("joão")
+
+        assertEquals(1, viewModel.uiState.value.moradores.size)
+        assertEquals("João Silva", viewModel.uiState.value.moradores.first().nome)
+    }
+
+    // --- Search by apartment number ---
+
+    @Test
+    fun `GIVEN moradores loaded WHEN query matches apartment number THEN filters results`() = runTest(testScheduler) {
+        loadMoradores(listOf(
+            makeMorador("João Silva", "101"),
+            makeMorador("Maria Santos", "102"),
+            makeMorador("Pedro Costa", "101")
+        ))
+
+        viewModel.setQuery("101")
+
+        assertEquals(2, viewModel.uiState.value.moradores.size)
+    }
+
+    @Test
+    fun `GIVEN moradores loaded WHEN query matches partial apartment number THEN filters results`() = runTest(testScheduler) {
+        loadMoradores(listOf(
+            makeMorador("João Silva", "101"),
+            makeMorador("Maria Santos", "201")
+        ))
+
+        viewModel.setQuery("01")
+
+        assertEquals(2, viewModel.uiState.value.moradores.size)
+    }
+
+    // --- Empty results ---
+
+    @Test
+    fun `GIVEN moradores loaded WHEN query matches nothing THEN returns empty list`() = runTest(testScheduler) {
+        loadMoradores(listOf(
+            makeMorador("João Silva", "101"),
+            makeMorador("Maria Santos", "102")
+        ))
+
+        viewModel.setQuery("xyz")
+
+        assertTrue(viewModel.uiState.value.moradores.isEmpty())
+    }
+
+    // --- Clear query ---
+
+    @Test
+    fun `GIVEN filtered results WHEN query cleared THEN shows all moradores`() = runTest(testScheduler) {
+        loadMoradores(listOf(
+            makeMorador("João Silva", "101"),
+            makeMorador("Maria Santos", "102")
+        ))
+
+        viewModel.setQuery("João")
+        assertEquals(1, viewModel.uiState.value.moradores.size)
+
+        viewModel.setQuery("")
+        assertEquals(2, viewModel.uiState.value.moradores.size)
+    }
+
+    // --- Navigation ---
+
+    @Test
+    fun `WHEN morador clicked THEN emits ApartamentoDetails event`() = runTest(testScheduler) {
+        viewModel.onMoradorClick("apt-123")
+
+        val event = viewModel.uiState.value.navigationEvent
+        assertIs<MoradorSearchNavigationEvent.ApartamentoDetails>(event)
+        assertEquals("apt-123", event.apartamentoId)
+    }
+
+    @Test
+    fun `GIVEN nav event WHEN handled THEN navigation event is cleared`() = runTest(testScheduler) {
+        viewModel.onMoradorClick("apt-123")
+        viewModel.onNavigationHandled()
+
+        assertNull(viewModel.uiState.value.navigationEvent)
+    }
+
+    // --- Helpers ---
+
+    private fun makeMorador(nome: String, aptNumero: String): Morador = Morador(
+        pessoa = Pessoa(
+            id = "pessoa-$nome",
+            cpf = "12345678900",
+            nome = nome,
+            email = "$nome@test.com",
+            telefone = "11999999999"
+        ),
+        apartamento = Apartamento(
+            id = "apt-$aptNumero",
+            numero = aptNumero,
+            andar = "1",
+            moradores = emptyList()
+        ),
+        tipo = MoradorTipo.RESIDENTE
+    )
+
+    private suspend fun loadMoradores(moradores: List<Morador>) {
+        everySuspending { moradoresRepository.getMoradoresForCondominio("condo-1") } returns Result.success(moradores)
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadMoradores()
+        testScheduler.advanceUntilIdle()
+    }
+}

--- a/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
+++ b/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
@@ -28,6 +28,7 @@ import com.zalamena.condominios.condominio.ui.addmorador.flowController.AddMorad
 import com.zalamena.condominios.condominio.ui.addmorador.overview.AddMoradorOverviewViewModel
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDashboardViewModel
 import com.zalamena.condominios.condominio.ui.condominio.overview.CondominioOverviewViewModel
+import com.zalamena.condominios.condominio.ui.moradores.search.MoradorSearchViewModel
 import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListViewModel
 import com.zalamena.condominios.condominio.domain.porteiro.models.PorteiroInfo
 import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroDeleter
@@ -155,4 +156,5 @@ val viewModelModule = module {
     viewModelOf(::SplashViewModel)
     viewModelOf(::CreateUserViewModel)
     viewModelOf(::PorteiroListViewModel)
+    viewModelOf(::MoradorSearchViewModel)
 }

--- a/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/api/FakeLoginApi.kt
+++ b/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/api/FakeLoginApi.kt
@@ -15,6 +15,17 @@ class FakeLoginApi(
             return LoginSessionDto(token = "fake-token-admin", userId = "user-1", expiresIn = 86400L)
         }
 
+        if (username == "porteiro" && password == "porteiro") {
+            val porteiro = userRepository.getUsers().getOrNull()
+                ?.firstOrNull { it.role is UserRole.Porteiro }
+                ?: throw LoginException.InvalidCredentialsException
+            return LoginSessionDto(
+                token = "fake-token-${porteiro.id}",
+                userId = porteiro.id,
+                expiresIn = 86400L
+            )
+        }
+
         val result = userRepository.authenticate(username, password)
         if (result.isSuccess) {
             val user = result.getOrThrow()

--- a/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
+++ b/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
@@ -35,8 +35,11 @@ import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDas
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDashboardViewModel
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.CondominioDashboardRoute
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.DoormanApartamentoDetailRoute
+import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.DoormanMoradorSearchRoute
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.condominioDashboardNavHost
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.doormanApartamentoDetail
+import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.doormanMoradorSearch
+import com.zalamena.condominios.condominio.ui.moradores.search.MoradorSearchViewModel
 import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListViewModel
 import com.zalamena.condominios.pessoa.ui.addpessoa.AddPessoaViewModel
 import com.zalamena.login.domain.models.UserRole
@@ -78,6 +81,7 @@ fun AppNavHost(
     adminHomeViewModel: AdminHomeViewModel,
     createUserViewModel: CreateUserViewModel,
     porteiroListViewModel: PorteiroListViewModel,
+    moradorSearchViewModel: MoradorSearchViewModel,
     onLogout: suspend () -> Unit = {}
 ) {
     NavHost(navController, startDestination = SplashRoute) {
@@ -177,6 +181,10 @@ fun AppNavHost(
                     apartamentoDetailViewModel.setApartamentoId(apartamentoId)
                     navController.navigate(DoormanApartamentoDetailRoute)
                 },
+                onNavigateToSearchMorador = { condominioId ->
+                    moradorSearchViewModel.setCondominioId(condominioId)
+                    navController.navigate(DoormanMoradorSearchRoute)
+                },
                 onLogout = {
                     coroutineScope.launch {
                         onLogout()
@@ -188,7 +196,9 @@ fun AppNavHost(
             )
         }
 
-        doormanApartamentoDetail(apartamentoDetailViewModel)
+        doormanApartamentoDetail(navController, apartamentoDetailViewModel)
+
+        doormanMoradorSearch(navController, moradorSearchViewModel, apartamentoDetailViewModel)
 
         loginNavHost(
             navController,


### PR DESCRIPTION
## Summary
- Add morador search screen for doorman: filter residents by name or apartment number (client-side)
- Add "Buscar Morador" button on doorman dashboard
- Add porteiro/porteiro debug login shortcut (logs in as first available porteiro)
- 14 ViewModel tests for search + 2 dashboard tests for navigation event

Closes #8

## Test plan
- [ ] Log in as porteiro (porteiro/porteiro) and tap "Buscar Morador"
- [ ] Search by resident name — results filter correctly
- [ ] Search by apartment number — results filter correctly
- [ ] Clear search field — all moradores shown
- [ ] Search with no matches — "Nenhum morador encontrado" message
- [ ] Tap a search result — navigates to apartment detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)