### PR TITLE
T7.5 · Morador detail screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/zalamena/condominios/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/zalamena/condominios/App.kt
@@ -69,6 +69,7 @@ fun App() {
             koinViewModel(),
             koinViewModel(),
             koinViewModel(),
+            koinViewModel(),
             onLogout = { logoutUseCase() }
         )
     }

--- a/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/apartamento/mapper/ApartamentoMapper.kt
+++ b/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/apartamento/mapper/ApartamentoMapper.kt
@@ -3,14 +3,26 @@ package com.zalamena.condominios.condominio.data.apartamento.mapper
 import com.zalamena.condominios.condominio.data.apartamento.entity.ApartamentoEntity
 import com.zalamena.condominios.condominio.data.apartamento.entity.ApartamentoWithAllData
 import com.zalamena.condominios.condominio.domain.apartamento.models.Apartamento
+import com.zalamena.condominios.condominio.domain.morador.model.Morador
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
 import com.zalamena.condominios.pessoa.data.mapper.toDomain
 
 fun ApartamentoWithAllData.toDomain(): Apartamento {
-    return Apartamento(
+    val apt = Apartamento(
         id = apartamento.id,
         numero = apartamento.numero,
         andar = apartamento.andar,
-        moradores = moradores.map { it.pessoa.toDomain() }
+        moradores = emptyList()
+    )
+    return apt.copy(
+        moradores = moradores.map { moradorWithPessoa ->
+            Morador(
+                pessoa = moradorWithPessoa.pessoa.toDomain(),
+                apartamento = apt,
+                tipo = runCatching { MoradorTipo.valueOf(moradorWithPessoa.morador.tipo) }
+                    .getOrDefault(MoradorTipo.RESIDENTE)
+            )
+        }
     )
 }
 

--- a/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/moradores/dao/MoradoresDao.kt
+++ b/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/moradores/dao/MoradoresDao.kt
@@ -44,4 +44,9 @@ interface MoradoresDao {
     """)
     @RewriteQueriesToDropUnusedColumns
     suspend fun getAllMoradoresForCondominio(condominioId: String): List<MoradorWithPessoaAndApartamentoEntity>
+
+    @Transaction
+    @Query("SELECT * FROM Morador WHERE pessoaId = :pessoaId")
+    @RewriteQueriesToDropUnusedColumns
+    suspend fun getAllMoradoresForPessoa(pessoaId: String): List<MoradorWithPessoaAndApartamentoEntity>
 }

--- a/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/moradores/repository/MoradoresRepositoryImpl.kt
+++ b/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/moradores/repository/MoradoresRepositoryImpl.kt
@@ -48,4 +48,10 @@ class MoradoresRepositoryImpl(
             moradoresDao.getAllMoradoresForCondominio(condominioId).map { it.toDomain() }
         }
     }
+
+    override suspend fun getMoradoresForPessoa(pessoaId: String): Result<List<Morador>> {
+        return runCatching {
+            moradoresDao.getAllMoradoresForPessoa(pessoaId).map { it.toDomain() }
+        }
+    }
 }

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/apartamento/models/Apartamento.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/apartamento/models/Apartamento.kt
@@ -1,5 +1,7 @@
 package com.zalamena.condominios.condominio.domain.apartamento.models
 
+import com.zalamena.condominios.condominio.domain.morador.model.Morador
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
 import com.zalamena.condominios.pessoa.domain.models.Pessoa
 
 
@@ -8,7 +10,7 @@ interface ApartamentoProperties {
     val numero: String
     val andar: String
 
-    val moradores: List<Pessoa>
+    val moradores: List<Morador>
 }
 
 
@@ -16,15 +18,26 @@ data class Apartamento(
     override val id: String,
     override val numero: String,
     override val andar: String,
-    override val moradores: List<Pessoa>
+    override val moradores: List<Morador>
 ): ApartamentoProperties {
 
     companion object {
-        val dummy = Apartamento(
-            id = "id",
-            numero = "numero",
-            andar = "andar",
-            moradores = listOf(Pessoa.dummy)
-        )
+        val dummy: Apartamento by lazy {
+            val apt = Apartamento(
+                id = "id",
+                numero = "numero",
+                andar = "andar",
+                moradores = emptyList()
+            )
+            apt.copy(
+                moradores = listOf(
+                    Morador(
+                        pessoa = Pessoa.dummy,
+                        apartamento = apt,
+                        tipo = MoradorTipo.RESIDENTE
+                    )
+                )
+            )
+        }
     }
 }

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/model/Morador.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/model/Morador.kt
@@ -13,7 +13,12 @@ data class Morador(
     companion object {
         val dummy = Morador(
             pessoa = Pessoa.dummy,
-            apartamento = Apartamento.dummy,
+            apartamento = Apartamento(
+                id = "id",
+                numero = "numero",
+                andar = "andar",
+                moradores = emptyList()
+            ),
             tipo = MoradorTipo.RESIDENTE
         )
     }

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/repository/MoradoresRepository.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/repository/MoradoresRepository.kt
@@ -11,4 +11,6 @@ interface MoradoresRepository {
     suspend fun getMoradoresForApartamento(apartamentoId: String): Result<List<Morador>>
 
     suspend fun getMoradoresForCondominio(condominioId: String): Result<List<Morador>>
+
+    suspend fun getMoradoresForPessoa(pessoaId: String): Result<List<Morador>>
 }

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/usecase/GetMoradorDetailUseCase.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/usecase/GetMoradorDetailUseCase.kt
@@ -1,0 +1,11 @@
+package com.zalamena.condominios.condominio.domain.morador.usecase
+
+import com.zalamena.condominios.condominio.domain.morador.model.Morador
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
+
+class GetMoradorDetailUseCase(
+    private val moradoresRepository: MoradoresRepository
+) {
+    suspend operator fun invoke(pessoaId: String): Result<List<Morador>> =
+        moradoresRepository.getMoradoresForPessoa(pessoaId)
+}

--- a/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/morador/GetMoradorDetailUseCaseTest.kt
+++ b/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/morador/GetMoradorDetailUseCaseTest.kt
@@ -1,0 +1,72 @@
+package com.zalamena.condominios.condominio.domain.morador
+
+import com.zalamena.condominios.condominio.domain.apartamento.models.Apartamento
+import com.zalamena.condominios.condominio.domain.morador.model.Morador
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
+import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradorDetailUseCase
+import com.zalamena.condominios.pessoa.domain.models.Pessoa
+import kotlinx.coroutines.test.runTest
+import org.kodein.mock.Mock
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GetMoradorDetailUseCaseTest : TestsWithMocks() {
+
+    @Mock
+    lateinit var moradoresRepository: MoradoresRepository
+
+    private val useCase by lazy { GetMoradorDetailUseCase(moradoresRepository) }
+
+    @Test
+    fun `GIVEN pessoa with moradores WHEN invoking THEN returns list of moradores`() = runTest {
+        val pessoa = Pessoa.dummy.copy(id = "pessoa-1")
+        val moradores = listOf(
+            Morador(
+                pessoa = pessoa,
+                apartamento = Apartamento(id = "apt-1", numero = "101", andar = "1", moradores = emptyList()),
+                tipo = MoradorTipo.PROPRIETARIO
+            ),
+            Morador(
+                pessoa = pessoa,
+                apartamento = Apartamento(id = "apt-2", numero = "202", andar = "2", moradores = emptyList()),
+                tipo = MoradorTipo.RESIDENTE
+            )
+        )
+
+        everySuspending { moradoresRepository.getMoradoresForPessoa("pessoa-1") } returns Result.success(moradores)
+
+        val result = useCase("pessoa-1")
+
+        assertTrue(result.isSuccess)
+        assertEquals(2, result.getOrThrow().size)
+        assertEquals(MoradorTipo.PROPRIETARIO, result.getOrThrow()[0].tipo)
+        assertEquals(MoradorTipo.RESIDENTE, result.getOrThrow()[1].tipo)
+    }
+
+    @Test
+    fun `GIVEN no moradores WHEN invoking THEN returns empty list`() = runTest {
+        everySuspending { moradoresRepository.getMoradoresForPessoa("pessoa-1") } returns Result.success(emptyList())
+
+        val result = useCase("pessoa-1")
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    @Test
+    fun `GIVEN repository fails WHEN invoking THEN propagates failure`() = runTest {
+        everySuspending { moradoresRepository.getMoradoresForPessoa("pessoa-1") } returns Result.failure(Exception("DB error"))
+
+        val result = useCase("pessoa-1")
+
+        assertTrue(result.isFailure)
+    }
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+}

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.zalamena.condominios.condominio.ui.apartamento.detail
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,7 +35,8 @@ import com.zalamena.condominios.condominio.ui.apartamento.detail.models.MoradorD
 fun ApartamentoDetailScreen(
     viewModel: ApartamentoDetailViewModel,
     isAdminMode: Boolean = true,
-    onNavigateToAddMorador: (apartamentoId: String) -> Unit = {}
+    onNavigateToAddMorador: (apartamentoId: String) -> Unit = {},
+    onNavigateToMoradorDetail: (pessoaId: String) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
@@ -53,6 +55,10 @@ fun ApartamentoDetailScreen(
         when (val event = uiState.navigationEvent) {
             is ApartamentoDetailNavEvent.AddMorador -> {
                 onNavigateToAddMorador(event.apartamentoId)
+                viewModel.onNavigationHandled()
+            }
+            is ApartamentoDetailNavEvent.MoradorDetail -> {
+                onNavigateToMoradorDetail(event.pessoaId)
                 viewModel.onNavigationHandled()
             }
             null -> Unit
@@ -74,7 +80,8 @@ fun ApartamentoDetailScreen(
                 ApartamentoDetailContent(
                     uiState = uiState,
                     isAdminMode = isAdminMode,
-                    onAddMoradorClick = viewModel::onAddMoradorClick
+                    onAddMoradorClick = viewModel::onAddMoradorClick,
+                    onMoradorClick = viewModel::onMoradorClick
                 )
             }
         }
@@ -85,7 +92,8 @@ fun ApartamentoDetailScreen(
 private fun ApartamentoDetailContent(
     uiState: ApartamentoDetailUiState,
     isAdminMode: Boolean = true,
-    onAddMoradorClick: () -> Unit = {}
+    onAddMoradorClick: () -> Unit = {},
+    onMoradorClick: (pessoaId: String) -> Unit = {}
 ) {
     Column(
         modifier = Modifier
@@ -105,7 +113,7 @@ private fun ApartamentoDetailContent(
         } else {
             LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 items(uiState.moradores) { morador ->
-                    MoradorRow(morador)
+                    MoradorRow(morador = morador, onClick = { onMoradorClick(morador.pessoaId) })
                 }
             }
         }
@@ -120,8 +128,8 @@ private fun ApartamentoDetailContent(
 }
 
 @Composable
-private fun MoradorRow(morador: MoradorDetailUiData) {
-    Card(modifier = Modifier.fillMaxWidth()) {
+private fun MoradorRow(morador: MoradorDetailUiData, onClick: () -> Unit = {}) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
         Row(
             modifier = Modifier.padding(16.dp).fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailViewModel.kt
@@ -26,6 +26,7 @@ data class ApartamentoDetailUiState(
 
 sealed class ApartamentoDetailNavEvent {
     data class AddMorador(val apartamentoId: String) : ApartamentoDetailNavEvent()
+    data class MoradorDetail(val pessoaId: String) : ApartamentoDetailNavEvent()
 }
 
 class ApartamentoDetailViewModel(
@@ -62,6 +63,7 @@ class ApartamentoDetailViewModel(
                             andar = apt.andar,
                             moradores = moradoresResult.getOrThrow().map { m ->
                                 MoradorDetailUiData(
+                                    pessoaId = m.pessoa.id,
                                     nome = m.nome,
                                     maskedCpf = maskCpf(m.cpf),
                                     tipoLabel = m.tipo.toLabel()
@@ -75,6 +77,10 @@ class ApartamentoDetailViewModel(
                 }
             }
         }
+    }
+
+    fun onMoradorClick(pessoaId: String) {
+        _uiState.update { it.copy(navigationEvent = ApartamentoDetailNavEvent.MoradorDetail(pessoaId)) }
     }
 
     fun onAddMoradorClick() {

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/models/MoradorDetailUiData.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/models/MoradorDetailUiData.kt
@@ -3,6 +3,7 @@ package com.zalamena.condominios.condominio.ui.apartamento.detail.models
 import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
 
 data class MoradorDetailUiData(
+    val pessoaId: String,
     val nome: String,
     val maskedCpf: String,
     val tipoLabel: String

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/CondominioDashboardNavHost.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/CondominioDashboardNavHost.kt
@@ -12,6 +12,8 @@ import com.zalamena.condominios.condominio.ui.apartamento.detail.ApartamentoDeta
 import com.zalamena.condominios.condominio.ui.apartamento.detail.ApartamentoDetailViewModel
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDashboardScreen
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDashboardViewModel
+import com.zalamena.condominios.condominio.ui.moradores.details.MoradorInfoScreen
+import com.zalamena.condominios.condominio.ui.moradores.details.MoradorInfoViewModel
 import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListScreen
 import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListViewModel
 import com.zalamena.login.ui.createuser.CreateUserViewModel
@@ -31,6 +33,9 @@ object ApartamentoDetailScreenRoute
 @Serializable
 object PorteiroListRoute
 
+@Serializable
+object AdminMoradorDetailRoute
+
 fun NavGraphBuilder.condominioDashboardNavHost(
     navController: NavController,
     viewModel: CondominioDashboardViewModel,
@@ -38,7 +43,8 @@ fun NavGraphBuilder.condominioDashboardNavHost(
     apartamentoDetailViewModel: ApartamentoDetailViewModel,
     addMoradorFlowViewModel: AddMoradorFlowViewModel,
     createUserViewModel: CreateUserViewModel,
-    porteiroListViewModel: PorteiroListViewModel
+    porteiroListViewModel: PorteiroListViewModel,
+    moradorInfoViewModel: MoradorInfoViewModel
 ) {
     navigation<CondominioDashboardRoute>(startDestination = CondominioDashboardScreenRoute) {
         composable<CondominioDashboardScreenRoute> {
@@ -73,8 +79,16 @@ fun NavGraphBuilder.condominioDashboardNavHost(
                     addMoradorFlowViewModel.reset()
                     addMoradorFlowViewModel.setCreatedApartamentoId(apartamentoId)
                     navController.navigate(AddMoradorRoute)
+                },
+                onNavigateToMoradorDetail = { pessoaId ->
+                    moradorInfoViewModel.setPessoaId(pessoaId)
+                    navController.navigate(AdminMoradorDetailRoute)
                 }
             )
+        }
+
+        composable<AdminMoradorDetailRoute> {
+            MoradorInfoScreen(viewModel = moradorInfoViewModel)
         }
 
         composable<PorteiroListRoute> {

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/CondominioDashboardNavHost.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/CondominioDashboardNavHost.kt
@@ -88,7 +88,15 @@ fun NavGraphBuilder.condominioDashboardNavHost(
         }
 
         composable<AdminMoradorDetailRoute> {
-            MoradorInfoScreen(viewModel = moradorInfoViewModel)
+            MoradorInfoScreen(
+                viewModel = moradorInfoViewModel,
+                onNavigateToApartamento = { apartamentoId ->
+                    apartamentoDetailViewModel.setApartamentoId(apartamentoId)
+                    navController.navigate(ApartamentoDetailScreenRoute) {
+                        popUpTo(AdminMoradorDetailRoute) { inclusive = true }
+                    }
+                }
+            )
         }
 
         composable<PorteiroListRoute> {

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/DoormanDashboardNavHost.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/DoormanDashboardNavHost.kt
@@ -5,6 +5,8 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.zalamena.condominios.condominio.ui.apartamento.detail.ApartamentoDetailScreen
 import com.zalamena.condominios.condominio.ui.apartamento.detail.ApartamentoDetailViewModel
+import com.zalamena.condominios.condominio.ui.moradores.details.MoradorInfoScreen
+import com.zalamena.condominios.condominio.ui.moradores.details.MoradorInfoViewModel
 import com.zalamena.condominios.condominio.ui.moradores.search.MoradorSearchScreen
 import com.zalamena.condominios.condominio.ui.moradores.search.MoradorSearchViewModel
 import kotlinx.serialization.Serializable
@@ -15,14 +17,22 @@ object DoormanApartamentoDetailRoute
 @Serializable
 object DoormanMoradorSearchRoute
 
+@Serializable
+object DoormanMoradorDetailRoute
+
 fun NavGraphBuilder.doormanApartamentoDetail(
     navController: NavController,
-    apartamentoDetailViewModel: ApartamentoDetailViewModel
+    apartamentoDetailViewModel: ApartamentoDetailViewModel,
+    moradorInfoViewModel: MoradorInfoViewModel
 ) {
     composable<DoormanApartamentoDetailRoute> {
         ApartamentoDetailScreen(
             viewModel = apartamentoDetailViewModel,
-            isAdminMode = false
+            isAdminMode = false,
+            onNavigateToMoradorDetail = { pessoaId ->
+                moradorInfoViewModel.setPessoaId(pessoaId)
+                navController.navigate(DoormanMoradorDetailRoute)
+            }
         )
     }
 }
@@ -30,15 +40,23 @@ fun NavGraphBuilder.doormanApartamentoDetail(
 fun NavGraphBuilder.doormanMoradorSearch(
     navController: NavController,
     moradorSearchViewModel: MoradorSearchViewModel,
-    apartamentoDetailViewModel: ApartamentoDetailViewModel
+    moradorInfoViewModel: MoradorInfoViewModel
 ) {
     composable<DoormanMoradorSearchRoute> {
         MoradorSearchScreen(
             viewModel = moradorSearchViewModel,
-            onNavigateToApartamento = { apartamentoId ->
-                apartamentoDetailViewModel.setApartamentoId(apartamentoId)
-                navController.navigate(DoormanApartamentoDetailRoute)
+            onNavigateToMoradorDetail = { pessoaId ->
+                moradorInfoViewModel.setPessoaId(pessoaId)
+                navController.navigate(DoormanMoradorDetailRoute)
             }
         )
+    }
+}
+
+fun NavGraphBuilder.doormanMoradorDetail(
+    moradorInfoViewModel: MoradorInfoViewModel
+) {
+    composable<DoormanMoradorDetailRoute> {
+        MoradorInfoScreen(viewModel = moradorInfoViewModel)
     }
 }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/DoormanDashboardNavHost.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/DoormanDashboardNavHost.kt
@@ -54,9 +54,19 @@ fun NavGraphBuilder.doormanMoradorSearch(
 }
 
 fun NavGraphBuilder.doormanMoradorDetail(
-    moradorInfoViewModel: MoradorInfoViewModel
+    navController: NavController,
+    moradorInfoViewModel: MoradorInfoViewModel,
+    apartamentoDetailViewModel: ApartamentoDetailViewModel
 ) {
     composable<DoormanMoradorDetailRoute> {
-        MoradorInfoScreen(viewModel = moradorInfoViewModel)
+        MoradorInfoScreen(
+            viewModel = moradorInfoViewModel,
+            onNavigateToApartamento = { apartamentoId ->
+                apartamentoDetailViewModel.setApartamentoId(apartamentoId)
+                navController.navigate(DoormanApartamentoDetailRoute) {
+                    popUpTo(DoormanMoradorDetailRoute) { inclusive = true }
+                }
+            }
+        )
     }
 }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoScreen.kt
@@ -1,58 +1,119 @@
 package com.zalamena.condominios.condominio.ui.moradores.details
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.zalamena.condominios.condominio.ui.moradores.models.MoradorUiData
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MoradorInfoScreen(
     viewModel: MoradorInfoViewModel
 ) {
-    MoradorInfoScreenContent(viewModel.uiState.value)
-}
+    val uiState by viewModel.uiState.collectAsState()
 
+    LaunchedEffect(Unit) {
+        viewModel.load()
+    }
 
-@Composable
-private fun MoradorInfoScreenContent(
-    uiState: UiState
-) {
-    if(uiState.morador != null) {
-        Column(
-            modifier = Modifier.fillMaxSize().background(Color.White),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Detalhes do Morador") })
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier.fillMaxSize().padding(padding)
         ) {
-            Text(
-                text = uiState.morador.nome
-            )
-
-            Spacer(Modifier.height(12.dp))
-
-            Text(
-                text = uiState.morador.apartamento.numero
-            )
+            when {
+                uiState.isLoading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+                uiState.isError -> {
+                    Text(
+                        text = "Erro ao carregar morador",
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+                else -> {
+                    MoradorDetailContent(uiState = uiState)
+                }
+            }
         }
     }
 }
 
-
-@Preview
 @Composable
-fun MoradorInfoScreenContentPreview() {
-    MoradorInfoScreenContent(
-        uiState = UiState(
-            morador = MoradorUiData.dummy
-        )
-    )
+private fun MoradorDetailContent(uiState: MoradorDetailUiState) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(uiState.nome, style = MaterialTheme.typography.headlineMedium)
+        Spacer(Modifier.height(4.dp))
+        Text(uiState.maskedCpf, style = MaterialTheme.typography.bodyMedium)
+        Spacer(Modifier.height(8.dp))
+        Text("Email: ${uiState.email}", style = MaterialTheme.typography.bodyMedium)
+        Text("Telefone: ${uiState.telefone}", style = MaterialTheme.typography.bodyMedium)
+
+        Spacer(Modifier.height(16.dp))
+        HorizontalDivider()
+        Spacer(Modifier.height(12.dp))
+
+        Text("Apartamentos", style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.height(8.dp))
+
+        if (uiState.apartamentos.isEmpty()) {
+            Text("Nenhum apartamento vinculado.", style = MaterialTheme.typography.bodyMedium)
+        } else {
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                items(uiState.apartamentos) { apt ->
+                    ApartamentoDoMoradorCard(apt)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ApartamentoDoMoradorCard(apt: ApartamentoDoMoradorUiData) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column {
+                Text("Apt ${apt.numero}", style = MaterialTheme.typography.titleSmall)
+                Text("Andar ${apt.andar}", style = MaterialTheme.typography.bodySmall)
+            }
+            Text(
+                text = apt.tipoLabel,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
 }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoScreen.kt
@@ -1,5 +1,6 @@
 package com.zalamena.condominios.condominio.ui.moradores.details
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,12 +31,23 @@ import androidx.compose.ui.unit.dp
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MoradorInfoScreen(
-    viewModel: MoradorInfoViewModel
+    viewModel: MoradorInfoViewModel,
+    onNavigateToApartamento: (apartamentoId: String) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.load()
+    }
+
+    LaunchedEffect(uiState.navigationEvent) {
+        when (val event = uiState.navigationEvent) {
+            is MoradorInfoNavigationEvent.ApartamentoDetails -> {
+                onNavigateToApartamento(event.apartamentoId)
+                viewModel.onNavigationHandled()
+            }
+            null -> Unit
+        }
     }
 
     Scaffold(
@@ -57,7 +69,10 @@ fun MoradorInfoScreen(
                     )
                 }
                 else -> {
-                    MoradorDetailContent(uiState = uiState)
+                    MoradorDetailContent(
+                        uiState = uiState,
+                        onApartamentoClick = viewModel::onApartamentoClick
+                    )
                 }
             }
         }
@@ -65,7 +80,10 @@ fun MoradorInfoScreen(
 }
 
 @Composable
-private fun MoradorDetailContent(uiState: MoradorDetailUiState) {
+private fun MoradorDetailContent(
+    uiState: MoradorDetailUiState,
+    onApartamentoClick: (apartamentoId: String) -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -90,7 +108,10 @@ private fun MoradorDetailContent(uiState: MoradorDetailUiState) {
         } else {
             LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 items(uiState.apartamentos) { apt ->
-                    ApartamentoDoMoradorCard(apt)
+                    ApartamentoDoMoradorCard(
+                        apt = apt,
+                        onClick = { onApartamentoClick(apt.apartamentoId) }
+                    )
                 }
             }
         }
@@ -98,8 +119,8 @@ private fun MoradorDetailContent(uiState: MoradorDetailUiState) {
 }
 
 @Composable
-private fun ApartamentoDoMoradorCard(apt: ApartamentoDoMoradorUiData) {
-    Card(modifier = Modifier.fillMaxWidth()) {
+private fun ApartamentoDoMoradorCard(apt: ApartamentoDoMoradorUiData, onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
         Row(
             modifier = Modifier.padding(16.dp).fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoViewModel.kt
@@ -1,51 +1,87 @@
 package com.zalamena.condominios.condominio.ui.moradores.details
 
-import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradorUseCase
-import com.zalamena.condominios.condominio.ui.moradores.mapper.toUi
-import com.zalamena.condominios.condominio.ui.moradores.models.MoradorUiData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradorDetailUseCase
+import com.zalamena.condominios.condominio.ui.apartamento.detail.models.maskCpf
+import com.zalamena.condominios.condominio.ui.apartamento.detail.models.toLabel
+import com.zalamena.condominios.common.ui.withMinLoading
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
-
-data class UiState(
-    val morador: MoradorUiData? = null,
-    val isLoading: Boolean = false
+data class ApartamentoDoMoradorUiData(
+    val apartamentoId: String,
+    val numero: String,
+    val andar: String,
+    val tipoLabel: String
 )
 
-class MoradorInfoViewModel constructor(
-    private val getMoradorUseCase: GetMoradorUseCase
-) {
-    private val _uiState: MutableStateFlow<UiState> = MutableStateFlow(UiState())
-    val uiState: StateFlow<UiState> = _uiState
+data class MoradorDetailUiState(
+    val nome: String = "",
+    val maskedCpf: String = "",
+    val email: String = "",
+    val telefone: String = "",
+    val apartamentos: List<ApartamentoDoMoradorUiData> = emptyList(),
+    val isLoading: Boolean = false,
+    val isError: Boolean = false
+)
 
+class MoradorInfoViewModel(
+    private val getMoradorDetailUseCase: GetMoradorDetailUseCase
+) : ViewModel() {
 
-    suspend fun getMorador(cpf: String, apartamentoId: String) {
-        _uiState.update {
-            it.copy(isLoading = true)
-        }
+    private val _uiState = MutableStateFlow(MoradorDetailUiState())
+    val uiState: StateFlow<MoradorDetailUiState> = _uiState.asStateFlow()
 
-        val moradorResult = getMoradorUseCase(cpf, apartamentoId)
+    private var pessoaId: String = ""
 
+    fun setPessoaId(pessoaId: String) {
+        this.pessoaId = pessoaId
+    }
 
-        when {
-            moradorResult.isSuccess -> {
-                _uiState.update {
-                    it.copy(
-                        morador = moradorResult.getOrThrow().toUi(),
-                        isLoading = false
-                    )
-                }
+    fun load() {
+        if (pessoaId.isBlank()) return
+
+        viewModelScope.launch {
+            val showSpinner = _uiState.value.nome.isBlank()
+            _uiState.update { it.copy(isLoading = showSpinner, isError = false) }
+
+            val result = withMinLoading(showSpinner) {
+                getMoradorDetailUseCase(pessoaId)
             }
 
-            moradorResult.isFailure -> {
-                _uiState.update {
-                    it.copy(
-                        morador = null,
-                        isLoading = false
-                    )
+            result
+                .onSuccess { moradores ->
+                    if (moradores.isEmpty()) {
+                        _uiState.update { it.copy(isLoading = false, isError = true) }
+                        return@launch
+                    }
+
+                    val first = moradores.first()
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            nome = first.nome,
+                            maskedCpf = maskCpf(first.cpf),
+                            email = first.email.ifBlank { "Nao informado" },
+                            telefone = first.telefone.ifBlank { "Nao informado" },
+                            apartamentos = moradores.map { m ->
+                                ApartamentoDoMoradorUiData(
+                                    apartamentoId = m.apartamento.id,
+                                    numero = m.apartamento.numero,
+                                    andar = m.apartamento.andar,
+                                    tipoLabel = m.tipo.toLabel()
+                                )
+                            }
+                        )
+                    }
                 }
-            }
+                .onFailure {
+                    _uiState.update { it.copy(isLoading = false, isError = true) }
+                }
         }
     }
 }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoViewModel.kt
@@ -19,6 +19,10 @@ data class ApartamentoDoMoradorUiData(
     val tipoLabel: String
 )
 
+sealed class MoradorInfoNavigationEvent {
+    data class ApartamentoDetails(val apartamentoId: String) : MoradorInfoNavigationEvent()
+}
+
 data class MoradorDetailUiState(
     val nome: String = "",
     val maskedCpf: String = "",
@@ -26,7 +30,8 @@ data class MoradorDetailUiState(
     val telefone: String = "",
     val apartamentos: List<ApartamentoDoMoradorUiData> = emptyList(),
     val isLoading: Boolean = false,
-    val isError: Boolean = false
+    val isError: Boolean = false,
+    val navigationEvent: MoradorInfoNavigationEvent? = null
 )
 
 class MoradorInfoViewModel(
@@ -83,5 +88,15 @@ class MoradorInfoViewModel(
                     _uiState.update { it.copy(isLoading = false, isError = true) }
                 }
         }
+    }
+
+    fun onApartamentoClick(apartamentoId: String) {
+        _uiState.update {
+            it.copy(navigationEvent = MoradorInfoNavigationEvent.ApartamentoDetails(apartamentoId))
+        }
+    }
+
+    fun onNavigationHandled() {
+        _uiState.update { it.copy(navigationEvent = null) }
     }
 }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/search/MoradorSearchScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/search/MoradorSearchScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun MoradorSearchScreen(
     viewModel: MoradorSearchViewModel,
-    onNavigateToApartamento: (apartamentoId: String) -> Unit = {}
+    onNavigateToMoradorDetail: (pessoaId: String) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
@@ -42,8 +42,8 @@ fun MoradorSearchScreen(
 
     LaunchedEffect(uiState.navigationEvent) {
         when (val event = uiState.navigationEvent) {
-            is MoradorSearchNavigationEvent.ApartamentoDetails -> {
-                onNavigateToApartamento(event.apartamentoId)
+            is MoradorSearchNavigationEvent.MoradorDetail -> {
+                onNavigateToMoradorDetail(event.pessoaId)
                 viewModel.onNavigationHandled()
             }
             null -> Unit
@@ -100,7 +100,7 @@ fun MoradorSearchScreen(
                             items(uiState.moradores) { morador ->
                                 MoradorSearchCard(
                                     morador = morador,
-                                    onClick = { viewModel.onMoradorClick(morador.apartamentoId) }
+                                    onClick = { viewModel.onMoradorClick(morador.pessoaId) }
                                 )
                             }
                         }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/search/MoradorSearchViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/search/MoradorSearchViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 data class MoradorSearchUiData(
+    val pessoaId: String,
     val nome: String,
     val maskedCpf: String,
     val tipoLabel: String,
@@ -29,7 +30,7 @@ data class MoradorSearchUiState(
 )
 
 sealed class MoradorSearchNavigationEvent {
-    data class ApartamentoDetails(val apartamentoId: String) : MoradorSearchNavigationEvent()
+    data class MoradorDetail(val pessoaId: String) : MoradorSearchNavigationEvent()
 }
 
 class MoradorSearchViewModel(
@@ -79,9 +80,9 @@ class MoradorSearchViewModel(
         }
     }
 
-    fun onMoradorClick(apartamentoId: String) {
+    fun onMoradorClick(pessoaId: String) {
         _uiState.update {
-            it.copy(navigationEvent = MoradorSearchNavigationEvent.ApartamentoDetails(apartamentoId))
+            it.copy(navigationEvent = MoradorSearchNavigationEvent.MoradorDetail(pessoaId))
         }
     }
 
@@ -103,6 +104,7 @@ class MoradorSearchViewModel(
     }
 
     private fun Morador.toSearchUiData() = MoradorSearchUiData(
+        pessoaId = pessoa.id,
         nome = nome,
         maskedCpf = maskCpf(cpf),
         tipoLabel = tipo.toLabel(),

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/apartamento/ApartamentoDetailViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/apartamento/ApartamentoDetailViewModelTest.kt
@@ -1,0 +1,112 @@
+package com.zalamena.condominios.ui.apartamento
+
+import com.zalamena.condominios.condominio.domain.apartamento.models.Apartamento
+import com.zalamena.condominios.condominio.domain.apartamento.repository.ApartamentosRepository
+import com.zalamena.condominios.condominio.domain.apartamento.usecase.GetApartamentoUseCase
+import com.zalamena.condominios.condominio.domain.apartamento.usecase.GetApartamentoUseCaseImpl
+import com.zalamena.condominios.condominio.domain.morador.model.Morador
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
+import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradoresForApartamentoUseCase
+import com.zalamena.condominios.condominio.ui.apartamento.detail.ApartamentoDetailNavEvent
+import com.zalamena.condominios.condominio.ui.apartamento.detail.ApartamentoDetailViewModel
+import com.zalamena.condominios.pessoa.domain.models.Pessoa
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.kodein.mock.Mock
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ApartamentoDetailViewModelTest : TestsWithMocks() {
+
+    @Mock
+    lateinit var apartamentosRepository: ApartamentosRepository
+
+    @Mock
+    lateinit var moradoresRepository: MoradoresRepository
+
+    private val testScheduler = TestCoroutineScheduler()
+    private val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+
+    private val getApartamentoUseCase: GetApartamentoUseCase by lazy { GetApartamentoUseCaseImpl(apartamentosRepository) }
+    private val getMoradoresForApartamentoUseCase by lazy { GetMoradoresForApartamentoUseCase(moradoresRepository) }
+    private val viewModel by lazy { ApartamentoDetailViewModel(getApartamentoUseCase, getMoradoresForApartamentoUseCase) }
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+
+    @Test
+    fun `WHEN onMoradorClick THEN emits MoradorDetail navigation event`() = runTest(testScheduler) {
+        viewModel.onMoradorClick("pessoa-123")
+
+        val event = viewModel.uiState.value.navigationEvent
+        assertIs<ApartamentoDetailNavEvent.MoradorDetail>(event)
+        assertEquals("pessoa-123", event.pessoaId)
+    }
+
+    @Test
+    fun `GIVEN MoradorDetail event WHEN onNavigationHandled THEN clears event`() = runTest(testScheduler) {
+        viewModel.onMoradorClick("pessoa-123")
+        viewModel.onNavigationHandled()
+
+        assertNull(viewModel.uiState.value.navigationEvent)
+    }
+
+    @Test
+    fun `WHEN onAddMoradorClick THEN emits AddMorador navigation event`() = runTest(testScheduler) {
+        viewModel.setApartamentoId("apt-1")
+        viewModel.onAddMoradorClick()
+
+        val event = viewModel.uiState.value.navigationEvent
+        assertIs<ApartamentoDetailNavEvent.AddMorador>(event)
+        assertEquals("apt-1", event.apartamentoId)
+    }
+
+    @Test
+    fun `GIVEN successful load WHEN load THEN moradores have pessoaId`() = runTest(testScheduler) {
+        val apt = Apartamento(id = "apt-1", numero = "101", andar = "1", moradores = emptyList())
+        val moradores = listOf(
+            Morador(
+                pessoa = Pessoa(id = "p-1", cpf = "12345678901", nome = "Joao", email = "", telefone = ""),
+                apartamento = apt,
+                tipo = MoradorTipo.RESIDENTE
+            )
+        )
+        everySuspending { apartamentosRepository.getApartamento("apt-1") } returns Result.success(apt)
+        everySuspending { moradoresRepository.getMoradoresForApartamento("apt-1") } returns Result.success(moradores)
+
+        viewModel.setApartamentoId("apt-1")
+        viewModel.load()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isError)
+        assertEquals(1, viewModel.uiState.value.moradores.size)
+        assertEquals("p-1", viewModel.uiState.value.moradores.first().pessoaId)
+    }
+}

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/moradores/MoradorInfoViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/moradores/MoradorInfoViewModelTest.kt
@@ -21,8 +21,10 @@ import org.kodein.mock.tests.TestsWithMocks
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import com.zalamena.condominios.condominio.ui.moradores.details.MoradorInfoNavigationEvent
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -170,5 +172,28 @@ class MoradorInfoViewModelTest : TestsWithMocks() {
 
         assertFalse(viewModel.uiState.value.isLoading)
         assertEquals("", viewModel.uiState.value.nome)
+    }
+
+    // --- Navigation ---
+
+    @Test
+    fun `WHEN onApartamentoClick THEN emits ApartamentoDetails navigation event`() = runTest(testScheduler) {
+        assertNull(viewModel.uiState.value.navigationEvent)
+
+        viewModel.onApartamentoClick("apt-42")
+
+        val event = viewModel.uiState.value.navigationEvent
+        assertTrue(event is MoradorInfoNavigationEvent.ApartamentoDetails)
+        assertEquals("apt-42", event.apartamentoId)
+    }
+
+    @Test
+    fun `GIVEN ApartamentoDetails event WHEN onNavigationHandled THEN clears event`() = runTest(testScheduler) {
+        viewModel.onApartamentoClick("apt-42")
+        assertTrue(viewModel.uiState.value.navigationEvent is MoradorInfoNavigationEvent.ApartamentoDetails)
+
+        viewModel.onNavigationHandled()
+
+        assertNull(viewModel.uiState.value.navigationEvent)
     }
 }

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/moradores/MoradorInfoViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/moradores/MoradorInfoViewModelTest.kt
@@ -1,56 +1,174 @@
 package com.zalamena.condominios.ui.moradores
 
+import com.zalamena.condominios.condominio.domain.apartamento.models.Apartamento
 import com.zalamena.condominios.condominio.domain.morador.model.Morador
-import com.zalamena.condominios.condominio.domain.morador.model.MoradorException
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
 import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
-import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradorUseCase
+import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradorDetailUseCase
 import com.zalamena.condominios.condominio.ui.moradores.details.MoradorInfoViewModel
-import com.zalamena.condominios.condominio.ui.moradores.mapper.toUi
+import com.zalamena.condominios.pessoa.domain.models.Pessoa
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.kodein.mock.Mock
 import org.kodein.mock.generated.injectMocks
 import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MoradorInfoViewModelTest : TestsWithMocks() {
 
     @Mock
     lateinit var moradoresRepository: MoradoresRepository
 
-    private val getMoradorUseCase by lazy { GetMoradorUseCase(moradoresRepository) }
-    private val viewModel by lazy { MoradorInfoViewModel(getMoradorUseCase) }
+    private val testScheduler = TestCoroutineScheduler()
+    private val testDispatcher = UnconfinedTestDispatcher(testScheduler)
 
-    @Test
-    fun `GIVEN initial state WHEN observing uiState THEN morador should be null`() = runTest {
-        assertNull(viewModel.uiState.value.morador)
-        assertFalse(viewModel.uiState.value.isLoading)
+    private val getMoradorDetailUseCase by lazy { GetMoradorDetailUseCase(moradoresRepository) }
+    private val viewModel by lazy { MoradorInfoViewModel(getMoradorDetailUseCase) }
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
     }
 
-    @Test
-    fun `GIVEN morador exists WHEN getting morador THEN should populate morador`() = runTest {
-        everySuspending { moradoresRepository.getMorador("cpf", "apartamentoId") } returns Result.success(Morador.dummy)
-
-        viewModel.getMorador("cpf", "apartamentoId")
-
-        assertFalse(viewModel.uiState.value.isLoading)
-        assertEquals(Morador.dummy.toUi(), viewModel.uiState.value.morador)
-    }
-
-    @Test
-    fun `GIVEN morador does not exist WHEN getting morador THEN morador should be null`() = runTest {
-        everySuspending { moradoresRepository.getMorador("cpf", "apartamentoId") } returns Result.failure(MoradorException.MoradorNotFoundException)
-
-        viewModel.getMorador("cpf", "apartamentoId")
-
-        assertFalse(viewModel.uiState.value.isLoading)
-        assertNull(viewModel.uiState.value.morador)
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
     }
 
     override fun setUpMocks() {
         mocker.injectMocks(this)
+    }
+
+    // --- Initial state ---
+
+    @Test
+    fun `GIVEN initial state WHEN observing THEN nome is empty`() = runTest(testScheduler) {
+        assertEquals("", viewModel.uiState.value.nome)
+        assertFalse(viewModel.uiState.value.isLoading)
+        assertFalse(viewModel.uiState.value.isError)
+    }
+
+    // --- Successful load ---
+
+    @Test
+    fun `GIVEN moradores exist WHEN load THEN populates pessoa info from first entry`() = runTest(testScheduler) {
+        val pessoa = Pessoa(id = "p1", cpf = "12345678901", nome = "Joao Silva", email = "joao@test.com", telefone = "11999999999")
+        val moradores = listOf(
+            Morador(
+                pessoa = pessoa,
+                apartamento = Apartamento(id = "apt-1", numero = "101", andar = "1", moradores = emptyList()),
+                tipo = MoradorTipo.PROPRIETARIO
+            )
+        )
+        everySuspending { moradoresRepository.getMoradoresForPessoa("p1") } returns Result.success(moradores)
+
+        viewModel.setPessoaId("p1")
+        viewModel.load()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertFalse(state.isError)
+        assertEquals("Joao Silva", state.nome)
+        assertEquals("***.***.***-01", state.maskedCpf)
+        assertEquals("joao@test.com", state.email)
+        assertEquals("11999999999", state.telefone)
+    }
+
+    @Test
+    fun `GIVEN multiple apartments WHEN load THEN lists all apartments`() = runTest(testScheduler) {
+        val pessoa = Pessoa(id = "p1", cpf = "12345678901", nome = "Joao", email = "j@t.com", telefone = "119")
+        val moradores = listOf(
+            Morador(pessoa = pessoa, apartamento = Apartamento("apt-1", "101", "1", emptyList()), tipo = MoradorTipo.PROPRIETARIO),
+            Morador(pessoa = pessoa, apartamento = Apartamento("apt-2", "202", "2", emptyList()), tipo = MoradorTipo.RESIDENTE)
+        )
+        everySuspending { moradoresRepository.getMoradoresForPessoa("p1") } returns Result.success(moradores)
+
+        viewModel.setPessoaId("p1")
+        viewModel.load()
+        advanceUntilIdle()
+
+        val apts = viewModel.uiState.value.apartamentos
+        assertEquals(2, apts.size)
+        assertEquals("101", apts[0].numero)
+        assertEquals("202", apts[1].numero)
+    }
+
+    // --- Missing info ---
+
+    @Test
+    fun `GIVEN blank email WHEN load THEN shows Nao informado`() = runTest(testScheduler) {
+        val pessoa = Pessoa(id = "p1", cpf = "12345678901", nome = "Maria", email = "", telefone = "119")
+        val moradores = listOf(
+            Morador(pessoa = pessoa, apartamento = Apartamento("apt-1", "101", "1", emptyList()), tipo = MoradorTipo.RESIDENTE)
+        )
+        everySuspending { moradoresRepository.getMoradoresForPessoa("p1") } returns Result.success(moradores)
+
+        viewModel.setPessoaId("p1")
+        viewModel.load()
+        advanceUntilIdle()
+
+        assertEquals("Nao informado", viewModel.uiState.value.email)
+    }
+
+    @Test
+    fun `GIVEN blank telefone WHEN load THEN shows Nao informado`() = runTest(testScheduler) {
+        val pessoa = Pessoa(id = "p1", cpf = "12345678901", nome = "Maria", email = "m@t.com", telefone = "")
+        val moradores = listOf(
+            Morador(pessoa = pessoa, apartamento = Apartamento("apt-1", "101", "1", emptyList()), tipo = MoradorTipo.RESIDENTE)
+        )
+        everySuspending { moradoresRepository.getMoradoresForPessoa("p1") } returns Result.success(moradores)
+
+        viewModel.setPessoaId("p1")
+        viewModel.load()
+        advanceUntilIdle()
+
+        assertEquals("Nao informado", viewModel.uiState.value.telefone)
+    }
+
+    // --- Error state ---
+
+    @Test
+    fun `GIVEN repository fails WHEN load THEN sets error state`() = runTest(testScheduler) {
+        everySuspending { moradoresRepository.getMoradoresForPessoa("p1") } returns Result.failure(Exception("DB error"))
+
+        viewModel.setPessoaId("p1")
+        viewModel.load()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isError)
+        assertFalse(viewModel.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `GIVEN empty moradores list WHEN load THEN sets error state`() = runTest(testScheduler) {
+        everySuspending { moradoresRepository.getMoradoresForPessoa("p1") } returns Result.success(emptyList())
+
+        viewModel.setPessoaId("p1")
+        viewModel.load()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isError)
+    }
+
+    @Test
+    fun `GIVEN blank pessoaId WHEN load THEN does nothing`() = runTest(testScheduler) {
+        viewModel.load()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isLoading)
+        assertEquals("", viewModel.uiState.value.nome)
     }
 }

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/moradores/MoradorSearchViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/moradores/MoradorSearchViewModelTest.kt
@@ -191,17 +191,17 @@ class MoradorSearchViewModelTest : TestsWithMocks() {
     // --- Navigation ---
 
     @Test
-    fun `WHEN morador clicked THEN emits ApartamentoDetails event`() = runTest(testScheduler) {
-        viewModel.onMoradorClick("apt-123")
+    fun `WHEN morador clicked THEN emits MoradorDetail event`() = runTest(testScheduler) {
+        viewModel.onMoradorClick("pessoa-123")
 
         val event = viewModel.uiState.value.navigationEvent
-        assertIs<MoradorSearchNavigationEvent.ApartamentoDetails>(event)
-        assertEquals("apt-123", event.apartamentoId)
+        assertIs<MoradorSearchNavigationEvent.MoradorDetail>(event)
+        assertEquals("pessoa-123", event.pessoaId)
     }
 
     @Test
     fun `GIVEN nav event WHEN handled THEN navigation event is cleared`() = runTest(testScheduler) {
-        viewModel.onMoradorClick("apt-123")
+        viewModel.onMoradorClick("pessoa-123")
         viewModel.onNavigationHandled()
 
         assertNull(viewModel.uiState.value.navigationEvent)

--- a/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
+++ b/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
@@ -19,6 +19,7 @@ import com.zalamena.condominios.condominio.domain.condominio.usecase.GetMoradore
 import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
 import com.zalamena.condominios.condominio.domain.morador.usecase.AddMoradorUseCase
 import com.zalamena.condominios.condominio.domain.morador.usecase.AddMoradorUseCaseImpl
+import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradorDetailUseCase
 import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradoresForApartamentoUseCase
 import com.zalamena.condominios.condominio.ui.adminhome.AdminHomeViewModel
 import com.zalamena.condominios.condominio.ui.addapartamento.AddApartamentoViewModel
@@ -28,6 +29,7 @@ import com.zalamena.condominios.condominio.ui.addmorador.flowController.AddMorad
 import com.zalamena.condominios.condominio.ui.addmorador.overview.AddMoradorOverviewViewModel
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDashboardViewModel
 import com.zalamena.condominios.condominio.ui.condominio.overview.CondominioOverviewViewModel
+import com.zalamena.condominios.condominio.ui.moradores.details.MoradorInfoViewModel
 import com.zalamena.condominios.condominio.ui.moradores.search.MoradorSearchViewModel
 import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListViewModel
 import com.zalamena.condominios.condominio.domain.porteiro.models.PorteiroInfo
@@ -134,6 +136,7 @@ val useCaseModule = module {
     factory { GetApartamentosUseCase(get()) }
     factory<AddMoradorUseCase> { AddMoradorUseCaseImpl(get()) }
     factory { GetMoradoresForApartamentoUseCase(get()) }
+    factory { GetMoradorDetailUseCase(get()) }
     factory { CreateUserUseCase(get(), get()) }
     factory { GetPorteirosByCondominioUseCase(get()) }
     factory { DeletePorteiroUseCase(get()) }
@@ -157,4 +160,5 @@ val viewModelModule = module {
     viewModelOf(::CreateUserViewModel)
     viewModelOf(::PorteiroListViewModel)
     viewModelOf(::MoradorSearchViewModel)
+    viewModelOf(::MoradorInfoViewModel)
 }

--- a/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
+++ b/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
@@ -35,10 +35,13 @@ import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDas
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDashboardViewModel
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.CondominioDashboardRoute
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.DoormanApartamentoDetailRoute
+import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.DoormanMoradorDetailRoute
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.DoormanMoradorSearchRoute
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.condominioDashboardNavHost
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.doormanApartamentoDetail
+import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.doormanMoradorDetail
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.navigation.doormanMoradorSearch
+import com.zalamena.condominios.condominio.ui.moradores.details.MoradorInfoViewModel
 import com.zalamena.condominios.condominio.ui.moradores.search.MoradorSearchViewModel
 import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListViewModel
 import com.zalamena.condominios.pessoa.ui.addpessoa.AddPessoaViewModel
@@ -82,6 +85,7 @@ fun AppNavHost(
     createUserViewModel: CreateUserViewModel,
     porteiroListViewModel: PorteiroListViewModel,
     moradorSearchViewModel: MoradorSearchViewModel,
+    moradorInfoViewModel: MoradorInfoViewModel,
     onLogout: suspend () -> Unit = {}
 ) {
     NavHost(navController, startDestination = SplashRoute) {
@@ -104,13 +108,13 @@ fun AppNavHost(
                         Text("Login")
                     }
                     Button(onClick = { navController.navigate(CondominioDashboardRoute) }) {
-                        Text("Dashboard de Condomínio")
+                        Text("Dashboard de Condominio")
                     }
                     Button(onClick = { navController.navigate(AddCondominioRoute) }) {
-                        Text("Adicionar Condomínio")
+                        Text("Adicionar Condominio")
                     }
                     Button(onClick = { navController.navigate(CreateUserRoute) }) {
-                        Text("Criar Usuário")
+                        Text("Criar Usuario")
                     }
                     Button(onClick = { navController.navigate(AddMoradorRoute) }) {
                         Text("Go to Add Morador Flow from scratch")
@@ -196,9 +200,11 @@ fun AppNavHost(
             )
         }
 
-        doormanApartamentoDetail(navController, apartamentoDetailViewModel)
+        doormanApartamentoDetail(navController, apartamentoDetailViewModel, moradorInfoViewModel)
 
-        doormanMoradorSearch(navController, moradorSearchViewModel, apartamentoDetailViewModel)
+        doormanMoradorSearch(navController, moradorSearchViewModel, moradorInfoViewModel)
+
+        doormanMoradorDetail(moradorInfoViewModel)
 
         loginNavHost(
             navController,
@@ -241,7 +247,8 @@ fun AppNavHost(
             apartamentoDetailViewModel,
             addMoradorFlowViewModel,
             createUserViewModel,
-            porteiroListViewModel
+            porteiroListViewModel,
+            moradorInfoViewModel
         )
 
         addCondominioNavHost(

--- a/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
+++ b/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
@@ -204,7 +204,7 @@ fun AppNavHost(
 
         doormanMoradorSearch(navController, moradorSearchViewModel, moradorInfoViewModel)
 
-        doormanMoradorDetail(moradorInfoViewModel)
+        doormanMoradorDetail(navController, moradorInfoViewModel, apartamentoDetailViewModel)
 
         loginNavHost(
             navController,


### PR DESCRIPTION
## Summary
- Add morador detail screen showing full pessoa info (name, CPF, email, phone) and all linked apartments with tipo
- Fix DDD: `Apartamento.moradores` changed from `List<Pessoa>` to `List<Morador>` (preserves tipo info)
- New `GetMoradorDetailUseCase` + `getMoradoresForPessoa()` repository method
- Morador cards clickable from both search results and apartment detail (admin + doorman)
- Apartment cards in morador detail navigate to apartment detail with back stack loop prevention (popUpTo)
- 14+ new tests across use case, ViewModel, and navigation

Closes #21

## Test plan
- [ ] From doorman search, tap a morador → see full detail (name, CPF, email, phone, apartments)
- [ ] From apartment detail, tap a morador card → same detail screen
- [ ] Morador in multiple apartments → all apartments listed
- [ ] Tap apartment card in morador detail → navigates to apartment detail
- [ ] Back button from apartment detail → returns correctly (no infinite loop)
- [ ] Missing email/phone → shows "Não informado"
- [ ] Works in both admin and doorman modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)