### PR TITLE
T8 · Morador management (remove + edit tipo)

### DIFF
--- a/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/moradores/dao/MoradoresDao.kt
+++ b/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/moradores/dao/MoradoresDao.kt
@@ -49,4 +49,10 @@ interface MoradoresDao {
     @Query("SELECT * FROM Morador WHERE pessoaId = :pessoaId")
     @RewriteQueriesToDropUnusedColumns
     suspend fun getAllMoradoresForPessoa(pessoaId: String): List<MoradorWithPessoaAndApartamentoEntity>
+
+    @Query("DELETE FROM Morador WHERE pessoaId = :pessoaId AND apartamentoId = :apartamentoId")
+    suspend fun deleteMorador(pessoaId: String, apartamentoId: String)
+
+    @Query("UPDATE Morador SET tipo = :tipo WHERE pessoaId = :pessoaId AND apartamentoId = :apartamentoId")
+    suspend fun updateMoradorTipo(pessoaId: String, apartamentoId: String, tipo: String)
 }

--- a/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/moradores/repository/MoradoresRepositoryImpl.kt
+++ b/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/moradores/repository/MoradoresRepositoryImpl.kt
@@ -54,4 +54,16 @@ class MoradoresRepositoryImpl(
             moradoresDao.getAllMoradoresForPessoa(pessoaId).map { it.toDomain() }
         }
     }
+
+    override suspend fun removeMorador(pessoaId: String, apartamentoId: String): Result<Unit> {
+        return runCatching {
+            moradoresDao.deleteMorador(pessoaId, apartamentoId)
+        }
+    }
+
+    override suspend fun updateMoradorTipo(pessoaId: String, apartamentoId: String, newTipo: MoradorTipo): Result<Unit> {
+        return runCatching {
+            moradoresDao.updateMoradorTipo(pessoaId, apartamentoId, newTipo.name)
+        }
+    }
 }

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/repository/MoradoresRepository.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/repository/MoradoresRepository.kt
@@ -13,4 +13,8 @@ interface MoradoresRepository {
     suspend fun getMoradoresForCondominio(condominioId: String): Result<List<Morador>>
 
     suspend fun getMoradoresForPessoa(pessoaId: String): Result<List<Morador>>
+
+    suspend fun removeMorador(pessoaId: String, apartamentoId: String): Result<Unit>
+
+    suspend fun updateMoradorTipo(pessoaId: String, apartamentoId: String, newTipo: MoradorTipo): Result<Unit>
 }

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/usecase/RemoveMoradorUseCase.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/usecase/RemoveMoradorUseCase.kt
@@ -1,0 +1,17 @@
+package com.zalamena.condominios.condominio.domain.morador.usecase
+
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
+
+interface RemoveMoradorUseCase {
+    suspend operator fun invoke(pessoaId: String, apartamentoId: String): Result<Unit>
+}
+
+class RemoveMoradorUseCaseImpl(
+    private val moradoresRepository: MoradoresRepository
+) : RemoveMoradorUseCase {
+    override suspend operator fun invoke(pessoaId: String, apartamentoId: String): Result<Unit> {
+        if (pessoaId.isBlank()) return Result.failure(IllegalArgumentException("pessoaId cannot be blank"))
+        if (apartamentoId.isBlank()) return Result.failure(IllegalArgumentException("apartamentoId cannot be blank"))
+        return moradoresRepository.removeMorador(pessoaId, apartamentoId)
+    }
+}

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/usecase/UpdateMoradorTipoUseCase.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/usecase/UpdateMoradorTipoUseCase.kt
@@ -1,0 +1,29 @@
+package com.zalamena.condominios.condominio.domain.morador.usecase
+
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorException
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
+
+interface UpdateMoradorTipoUseCase {
+    suspend operator fun invoke(pessoaId: String, apartamentoId: String, newTipo: MoradorTipo): Result<Unit>
+}
+
+class UpdateMoradorTipoUseCaseImpl(
+    private val moradoresRepository: MoradoresRepository
+) : UpdateMoradorTipoUseCase {
+    override suspend operator fun invoke(
+        pessoaId: String,
+        apartamentoId: String,
+        newTipo: MoradorTipo
+    ): Result<Unit> {
+        if (newTipo == MoradorTipo.PROPRIETARIO) {
+            val existing = moradoresRepository.getMoradoresForApartamento(apartamentoId)
+                .getOrElse { emptyList() }
+            val otherProprietarios = existing.count { it.tipo == MoradorTipo.PROPRIETARIO && it.pessoa.id != pessoaId }
+            if (otherProprietarios >= 2) {
+                return Result.failure(MoradorException.MaxProprietariosExceededException)
+            }
+        }
+        return moradoresRepository.updateMoradorTipo(pessoaId, apartamentoId, newTipo)
+    }
+}

--- a/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/morador/RemoveMoradorUseCaseTest.kt
+++ b/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/morador/RemoveMoradorUseCaseTest.kt
@@ -1,0 +1,57 @@
+package com.zalamena.condominios.condominio.domain.morador
+
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
+import com.zalamena.condominios.condominio.domain.morador.usecase.RemoveMoradorUseCaseImpl
+import kotlinx.coroutines.test.runTest
+import org.kodein.mock.Mock
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class RemoveMoradorUseCaseTest : TestsWithMocks() {
+
+    @Mock
+    lateinit var moradoresRepository: MoradoresRepository
+
+    private val removeMoradorUseCase by lazy { RemoveMoradorUseCaseImpl(moradoresRepository) }
+
+    @Test
+    fun `GIVEN blank pessoaId WHEN removing THEN should fail with IllegalArgumentException`() = runTest {
+        val result = removeMoradorUseCase("", "apartamentoId")
+
+        assertTrue(result.isFailure)
+        assertIs<IllegalArgumentException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `GIVEN blank apartamentoId WHEN removing THEN should fail with IllegalArgumentException`() = runTest {
+        val result = removeMoradorUseCase("pessoaId", "")
+
+        assertTrue(result.isFailure)
+        assertIs<IllegalArgumentException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `GIVEN valid IDs WHEN removing THEN should delegate to repository`() = runTest {
+        everySuspending { moradoresRepository.removeMorador("pessoaId", "apartamentoId") } returns Result.success(Unit)
+
+        val result = removeMoradorUseCase("pessoaId", "apartamentoId")
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `GIVEN repository fails WHEN removing THEN should propagate failure`() = runTest {
+        everySuspending { moradoresRepository.removeMorador("pessoaId", "apartamentoId") } returns Result.failure(Exception("DB error"))
+
+        val result = removeMoradorUseCase("pessoaId", "apartamentoId")
+
+        assertTrue(result.isFailure)
+    }
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+}

--- a/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/morador/UpdateMoradorTipoUseCaseTest.kt
+++ b/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/morador/UpdateMoradorTipoUseCaseTest.kt
@@ -1,0 +1,99 @@
+package com.zalamena.condominios.condominio.domain.morador
+
+import com.zalamena.condominios.condominio.domain.morador.model.Morador
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorException
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
+import com.zalamena.condominios.condominio.domain.morador.usecase.UpdateMoradorTipoUseCaseImpl
+import com.zalamena.condominios.pessoa.domain.models.Pessoa
+import kotlinx.coroutines.test.runTest
+import org.kodein.mock.Mock
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class UpdateMoradorTipoUseCaseTest : TestsWithMocks() {
+
+    @Mock
+    lateinit var moradoresRepository: MoradoresRepository
+
+    private val updateMoradorTipoUseCase by lazy { UpdateMoradorTipoUseCaseImpl(moradoresRepository) }
+
+    @Test
+    fun `GIVEN changing to RESIDENTE WHEN updating THEN should succeed without checking proprietario count`() = runTest {
+        everySuspending { moradoresRepository.updateMoradorTipo("pessoaId", "apartamentoId", MoradorTipo.RESIDENTE) } returns Result.success(Unit)
+
+        val result = updateMoradorTipoUseCase("pessoaId", "apartamentoId", MoradorTipo.RESIDENTE)
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `GIVEN 0 existing proprietarios WHEN changing to PROPRIETARIO THEN should succeed`() = runTest {
+        everySuspending { moradoresRepository.getMoradoresForApartamento("apartamentoId") } returns Result.success(emptyList())
+        everySuspending { moradoresRepository.updateMoradorTipo("pessoaId", "apartamentoId", MoradorTipo.PROPRIETARIO) } returns Result.success(Unit)
+
+        val result = updateMoradorTipoUseCase("pessoaId", "apartamentoId", MoradorTipo.PROPRIETARIO)
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `GIVEN 1 existing proprietario (other person) WHEN changing to PROPRIETARIO THEN should succeed`() = runTest {
+        val existing = listOf(
+            Morador.dummy.copy(
+                pessoa = Pessoa.dummy.copy(id = "other-pessoa"),
+                tipo = MoradorTipo.PROPRIETARIO
+            )
+        )
+        everySuspending { moradoresRepository.getMoradoresForApartamento("apartamentoId") } returns Result.success(existing)
+        everySuspending { moradoresRepository.updateMoradorTipo("pessoaId", "apartamentoId", MoradorTipo.PROPRIETARIO) } returns Result.success(Unit)
+
+        val result = updateMoradorTipoUseCase("pessoaId", "apartamentoId", MoradorTipo.PROPRIETARIO)
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `GIVEN 2 existing proprietarios (other people) WHEN changing to PROPRIETARIO THEN should fail`() = runTest {
+        val existing = listOf(
+            Morador.dummy.copy(pessoa = Pessoa.dummy.copy(id = "other-1"), tipo = MoradorTipo.PROPRIETARIO),
+            Morador.dummy.copy(pessoa = Pessoa.dummy.copy(id = "other-2"), tipo = MoradorTipo.PROPRIETARIO)
+        )
+        everySuspending { moradoresRepository.getMoradoresForApartamento("apartamentoId") } returns Result.success(existing)
+
+        val result = updateMoradorTipoUseCase("pessoaId", "apartamentoId", MoradorTipo.PROPRIETARIO)
+
+        assertTrue(result.isFailure)
+        assertIs<MoradorException.MaxProprietariosExceededException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `GIVEN morador is already PROPRIETARIO and 1 other PROPRIETARIO exists WHEN re-saving as PROPRIETARIO THEN should succeed`() = runTest {
+        val existing = listOf(
+            Morador.dummy.copy(pessoa = Pessoa.dummy.copy(id = "pessoaId"), tipo = MoradorTipo.PROPRIETARIO),
+            Morador.dummy.copy(pessoa = Pessoa.dummy.copy(id = "other-1"), tipo = MoradorTipo.PROPRIETARIO)
+        )
+        everySuspending { moradoresRepository.getMoradoresForApartamento("apartamentoId") } returns Result.success(existing)
+        everySuspending { moradoresRepository.updateMoradorTipo("pessoaId", "apartamentoId", MoradorTipo.PROPRIETARIO) } returns Result.success(Unit)
+
+        val result = updateMoradorTipoUseCase("pessoaId", "apartamentoId", MoradorTipo.PROPRIETARIO)
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `GIVEN repository fails WHEN updating THEN should propagate failure`() = runTest {
+        everySuspending { moradoresRepository.updateMoradorTipo("pessoaId", "apartamentoId", MoradorTipo.RESIDENTE) } returns Result.failure(Exception("DB error"))
+
+        val result = updateMoradorTipoUseCase("pessoaId", "apartamentoId", MoradorTipo.RESIDENTE)
+
+        assertTrue(result.isFailure)
+    }
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+}

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailScreen.kt
@@ -10,14 +10,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -81,10 +85,19 @@ fun ApartamentoDetailScreen(
                     uiState = uiState,
                     isAdminMode = isAdminMode,
                     onAddMoradorClick = viewModel::onAddMoradorClick,
-                    onMoradorClick = viewModel::onMoradorClick
+                    onMoradorClick = viewModel::onMoradorClick,
+                    onDeleteMoradorClick = viewModel::onDeleteMoradorClick
                 )
             }
         }
+    }
+
+    uiState.showDeleteConfirmation?.let { morador ->
+        DeleteMoradorConfirmationDialog(
+            moradorName = morador.nome,
+            onConfirm = { viewModel.onConfirmDeleteMorador() },
+            onDismiss = { viewModel.onDismissDeleteMorador() }
+        )
     }
 }
 
@@ -93,7 +106,8 @@ private fun ApartamentoDetailContent(
     uiState: ApartamentoDetailUiState,
     isAdminMode: Boolean = true,
     onAddMoradorClick: () -> Unit = {},
-    onMoradorClick: (pessoaId: String) -> Unit = {}
+    onMoradorClick: (pessoaId: String) -> Unit = {},
+    onDeleteMoradorClick: (MoradorDetailUiData) -> Unit = {}
 ) {
     Column(
         modifier = Modifier
@@ -113,7 +127,12 @@ private fun ApartamentoDetailContent(
         } else {
             LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 items(uiState.moradores) { morador ->
-                    MoradorRow(morador = morador, onClick = { onMoradorClick(morador.pessoaId) })
+                    MoradorRow(
+                        morador = morador,
+                        isAdminMode = isAdminMode,
+                        onClick = { onMoradorClick(morador.pessoaId) },
+                        onDeleteClick = { onDeleteMoradorClick(morador) }
+                    )
                 }
             }
         }
@@ -128,14 +147,19 @@ private fun ApartamentoDetailContent(
 }
 
 @Composable
-private fun MoradorRow(morador: MoradorDetailUiData, onClick: () -> Unit = {}) {
+private fun MoradorRow(
+    morador: MoradorDetailUiData,
+    isAdminMode: Boolean = true,
+    onClick: () -> Unit = {},
+    onDeleteClick: () -> Unit = {}
+) {
     Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
         Row(
             modifier = Modifier.padding(16.dp).fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Column {
+            Column(modifier = Modifier.weight(1f)) {
                 Text(morador.nome, style = MaterialTheme.typography.bodyLarge)
                 Text(
                     text = morador.tipoLabel,
@@ -148,6 +172,40 @@ private fun MoradorRow(morador: MoradorDetailUiData, onClick: () -> Unit = {}) {
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            if (isAdminMode) {
+                Spacer(Modifier.width(8.dp))
+                Button(
+                    onClick = onDeleteClick,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Text("Excluir")
+                }
+            }
         }
     }
+}
+
+@Composable
+private fun DeleteMoradorConfirmationDialog(
+    moradorName: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Excluir morador") },
+        text = { Text("Tem certeza que deseja excluir o morador $moradorName?") },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text("Excluir", color = MaterialTheme.colorScheme.error)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancelar")
+            }
+        }
+    )
 }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zalamena.condominios.condominio.domain.apartamento.usecase.GetApartamentoUseCase
 import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradoresForApartamentoUseCase
+import com.zalamena.condominios.condominio.domain.morador.usecase.RemoveMoradorUseCase
 import com.zalamena.condominios.condominio.ui.apartamento.detail.models.MoradorDetailUiData
 import com.zalamena.condominios.condominio.ui.apartamento.detail.models.maskCpf
 import com.zalamena.condominios.condominio.ui.apartamento.detail.models.toLabel
@@ -21,7 +22,8 @@ data class ApartamentoDetailUiState(
     val moradores: List<MoradorDetailUiData> = emptyList(),
     val isLoading: Boolean = true,
     val isError: Boolean = false,
-    val navigationEvent: ApartamentoDetailNavEvent? = null
+    val navigationEvent: ApartamentoDetailNavEvent? = null,
+    val showDeleteConfirmation: MoradorDetailUiData? = null
 )
 
 sealed class ApartamentoDetailNavEvent {
@@ -31,7 +33,8 @@ sealed class ApartamentoDetailNavEvent {
 
 class ApartamentoDetailViewModel(
     private val getApartamentoUseCase: GetApartamentoUseCase,
-    private val getMoradoresForApartamentoUseCase: GetMoradoresForApartamentoUseCase
+    private val getMoradoresForApartamentoUseCase: GetMoradoresForApartamentoUseCase,
+    private val removeMoradorUseCase: RemoveMoradorUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ApartamentoDetailUiState())
@@ -64,6 +67,7 @@ class ApartamentoDetailViewModel(
                             moradores = moradoresResult.getOrThrow().map { m ->
                                 MoradorDetailUiData(
                                     pessoaId = m.pessoa.id,
+                                    apartamentoId = apartamentoId,
                                     nome = m.nome,
                                     maskedCpf = maskCpf(m.cpf),
                                     tipoLabel = m.tipo.toLabel()
@@ -91,5 +95,27 @@ class ApartamentoDetailViewModel(
 
     fun onNavigationHandled() {
         _uiState.update { it.copy(navigationEvent = null) }
+    }
+
+    fun onDeleteMoradorClick(morador: MoradorDetailUiData) {
+        _uiState.update { it.copy(showDeleteConfirmation = morador) }
+    }
+
+    fun onConfirmDeleteMorador() {
+        val morador = _uiState.value.showDeleteConfirmation ?: return
+        viewModelScope.launch {
+            removeMoradorUseCase(morador.pessoaId, morador.apartamentoId)
+                .onSuccess {
+                    _uiState.update { it.copy(showDeleteConfirmation = null) }
+                    load()
+                }
+                .onFailure {
+                    _uiState.update { it.copy(showDeleteConfirmation = null) }
+                }
+        }
+    }
+
+    fun onDismissDeleteMorador() {
+        _uiState.update { it.copy(showDeleteConfirmation = null) }
     }
 }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/ApartamentoDetailViewModel.kt
@@ -41,7 +41,9 @@ class ApartamentoDetailViewModel(
     val uiState: StateFlow<ApartamentoDetailUiState> = _uiState.asStateFlow()
 
     fun setApartamentoId(apartamentoId: String) {
-        _uiState.update { it.copy(apartamentoId = apartamentoId) }
+        _uiState.update {
+            ApartamentoDetailUiState(apartamentoId = apartamentoId)
+        }
     }
 
     fun load() {

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/models/MoradorDetailUiData.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/apartamento/detail/models/MoradorDetailUiData.kt
@@ -4,6 +4,7 @@ import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
 
 data class MoradorDetailUiData(
     val pessoaId: String,
+    val apartamentoId: String = "",
     val nome: String,
     val maskedCpf: String,
     val tipoLabel: String

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/CondominioDashboardNavHost.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/CondominioDashboardNavHost.kt
@@ -88,8 +88,10 @@ fun NavGraphBuilder.condominioDashboardNavHost(
         }
 
         composable<AdminMoradorDetailRoute> {
+            moradorInfoViewModel.setAdminMode(true)
             MoradorInfoScreen(
                 viewModel = moradorInfoViewModel,
+                isAdminMode = true,
                 onNavigateToApartamento = { apartamentoId ->
                     apartamentoDetailViewModel.setApartamentoId(apartamentoId)
                     navController.navigate(ApartamentoDetailScreenRoute) {

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoScreen.kt
@@ -10,13 +10,20 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -24,14 +31,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
+import com.zalamena.condominios.condominio.ui.apartamento.detail.models.toLabel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MoradorInfoScreen(
     viewModel: MoradorInfoViewModel,
+    isAdminMode: Boolean = false,
     onNavigateToApartamento: (apartamentoId: String) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -71,7 +84,9 @@ fun MoradorInfoScreen(
                 else -> {
                     MoradorDetailContent(
                         uiState = uiState,
-                        onApartamentoClick = viewModel::onApartamentoClick
+                        isAdminMode = isAdminMode,
+                        onApartamentoClick = viewModel::onApartamentoClick,
+                        onSaveTipo = viewModel::onSaveTipo
                     )
                 }
             }
@@ -82,7 +97,9 @@ fun MoradorInfoScreen(
 @Composable
 private fun MoradorDetailContent(
     uiState: MoradorDetailUiState,
-    onApartamentoClick: (apartamentoId: String) -> Unit
+    isAdminMode: Boolean,
+    onApartamentoClick: (apartamentoId: String) -> Unit,
+    onSaveTipo: (apartamentoId: String, newTipo: MoradorTipo) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -103,6 +120,15 @@ private fun MoradorDetailContent(
         Text("Apartamentos", style = MaterialTheme.typography.titleMedium)
         Spacer(Modifier.height(8.dp))
 
+        if (uiState.tipoError != null) {
+            Text(
+                text = uiState.tipoError,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error
+            )
+            Spacer(Modifier.height(8.dp))
+        }
+
         if (uiState.apartamentos.isEmpty()) {
             Text("Nenhum apartamento vinculado.", style = MaterialTheme.typography.bodyMedium)
         } else {
@@ -110,7 +136,9 @@ private fun MoradorDetailContent(
                 items(uiState.apartamentos) { apt ->
                     ApartamentoDoMoradorCard(
                         apt = apt,
-                        onClick = { onApartamentoClick(apt.apartamentoId) }
+                        isAdminMode = isAdminMode,
+                        onClick = { onApartamentoClick(apt.apartamentoId) },
+                        onSaveTipo = { newTipo -> onSaveTipo(apt.apartamentoId, newTipo) }
                     )
                 }
             }
@@ -118,23 +146,82 @@ private fun MoradorDetailContent(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun ApartamentoDoMoradorCard(apt: ApartamentoDoMoradorUiData, onClick: () -> Unit) {
+private fun ApartamentoDoMoradorCard(
+    apt: ApartamentoDoMoradorUiData,
+    isAdminMode: Boolean,
+    onClick: () -> Unit,
+    onSaveTipo: (MoradorTipo) -> Unit
+) {
+    var selectedTipo by remember(apt.apartamentoId, apt.tipo) { mutableStateOf(apt.tipo) }
+    var expanded by remember { mutableStateOf(false) }
+    val hasChanged = selectedTipo != apt.tipo
+
     Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
-        Row(
-            modifier = Modifier.padding(16.dp).fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column {
-                Text("Apt ${apt.numero}", style = MaterialTheme.typography.titleSmall)
-                Text("Andar ${apt.andar}", style = MaterialTheme.typography.bodySmall)
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column {
+                    Text("Apt ${apt.numero}", style = MaterialTheme.typography.titleSmall)
+                    Text("Andar ${apt.andar}", style = MaterialTheme.typography.bodySmall)
+                }
+                if (!isAdminMode) {
+                    Text(
+                        text = apt.tipoLabel,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
             }
-            Text(
-                text = apt.tipoLabel,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.primary
-            )
+
+            if (isAdminMode) {
+                Spacer(Modifier.height(12.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    ExposedDropdownMenuBox(
+                        expanded = expanded,
+                        onExpandedChange = { expanded = it },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        OutlinedTextField(
+                            value = selectedTipo.toLabel(),
+                            onValueChange = {},
+                            readOnly = true,
+                            label = { Text("Tipo") },
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                            modifier = Modifier
+                                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                                .fillMaxWidth()
+                        )
+                        ExposedDropdownMenu(
+                            expanded = expanded,
+                            onDismissRequest = { expanded = false }
+                        ) {
+                            MoradorTipo.entries.forEach { tipo ->
+                                DropdownMenuItem(
+                                    text = { Text(tipo.toLabel()) },
+                                    onClick = {
+                                        selectedTipo = tipo
+                                        expanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                    if (hasChanged) {
+                        Spacer(Modifier.width(8.dp))
+                        Button(onClick = { onSaveTipo(selectedTipo) }) {
+                            Text("Salvar")
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoViewModel.kt
@@ -2,7 +2,10 @@ package com.zalamena.condominios.condominio.ui.moradores.details
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorException
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
 import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradorDetailUseCase
+import com.zalamena.condominios.condominio.domain.morador.usecase.UpdateMoradorTipoUseCase
 import com.zalamena.condominios.condominio.ui.apartamento.detail.models.maskCpf
 import com.zalamena.condominios.condominio.ui.apartamento.detail.models.toLabel
 import com.zalamena.condominios.common.ui.withMinLoading
@@ -16,7 +19,8 @@ data class ApartamentoDoMoradorUiData(
     val apartamentoId: String,
     val numero: String,
     val andar: String,
-    val tipoLabel: String
+    val tipoLabel: String,
+    val tipo: MoradorTipo = MoradorTipo.RESIDENTE
 )
 
 sealed class MoradorInfoNavigationEvent {
@@ -31,11 +35,14 @@ data class MoradorDetailUiState(
     val apartamentos: List<ApartamentoDoMoradorUiData> = emptyList(),
     val isLoading: Boolean = false,
     val isError: Boolean = false,
-    val navigationEvent: MoradorInfoNavigationEvent? = null
+    val navigationEvent: MoradorInfoNavigationEvent? = null,
+    val isAdminMode: Boolean = false,
+    val tipoError: String? = null
 )
 
 class MoradorInfoViewModel(
-    private val getMoradorDetailUseCase: GetMoradorDetailUseCase
+    private val getMoradorDetailUseCase: GetMoradorDetailUseCase,
+    private val updateMoradorTipoUseCase: UpdateMoradorTipoUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MoradorDetailUiState())
@@ -78,7 +85,8 @@ class MoradorInfoViewModel(
                                     apartamentoId = m.apartamento.id,
                                     numero = m.apartamento.numero,
                                     andar = m.apartamento.andar,
-                                    tipoLabel = m.tipo.toLabel()
+                                    tipoLabel = m.tipo.toLabel(),
+                                    tipo = m.tipo
                                 )
                             }
                         )
@@ -98,5 +106,26 @@ class MoradorInfoViewModel(
 
     fun onNavigationHandled() {
         _uiState.update { it.copy(navigationEvent = null) }
+    }
+
+    fun setAdminMode(isAdmin: Boolean) {
+        _uiState.update { it.copy(isAdminMode = isAdmin) }
+    }
+
+    fun onSaveTipo(apartamentoId: String, newTipo: MoradorTipo) {
+        if (pessoaId.isBlank()) return
+
+        viewModelScope.launch {
+            updateMoradorTipoUseCase(pessoaId, apartamentoId, newTipo)
+                .onSuccess {
+                    _uiState.update { it.copy(tipoError = null) }
+                    load()
+                }
+                .onFailure { error ->
+                    if (error is MoradorException.MaxProprietariosExceededException) {
+                        _uiState.update { it.copy(tipoError = "Limite de 2 proprietarios por apartamento atingido") }
+                    }
+                }
+        }
     }
 }

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/apartamento/ApartamentoDetailViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/apartamento/ApartamentoDetailViewModelTest.kt
@@ -8,6 +8,8 @@ import com.zalamena.condominios.condominio.domain.morador.model.Morador
 import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
 import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
 import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradoresForApartamentoUseCase
+import com.zalamena.condominios.condominio.domain.morador.usecase.RemoveMoradorUseCase
+import com.zalamena.condominios.condominio.domain.morador.usecase.RemoveMoradorUseCaseImpl
 import com.zalamena.condominios.condominio.ui.apartamento.detail.ApartamentoDetailNavEvent
 import com.zalamena.condominios.condominio.ui.apartamento.detail.ApartamentoDetailViewModel
 import com.zalamena.condominios.pessoa.domain.models.Pessoa
@@ -28,6 +30,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -45,7 +48,8 @@ class ApartamentoDetailViewModelTest : TestsWithMocks() {
 
     private val getApartamentoUseCase: GetApartamentoUseCase by lazy { GetApartamentoUseCaseImpl(apartamentosRepository) }
     private val getMoradoresForApartamentoUseCase by lazy { GetMoradoresForApartamentoUseCase(moradoresRepository) }
-    private val viewModel by lazy { ApartamentoDetailViewModel(getApartamentoUseCase, getMoradoresForApartamentoUseCase) }
+    private val removeMoradorUseCase: RemoveMoradorUseCase by lazy { RemoveMoradorUseCaseImpl(moradoresRepository) }
+    private val viewModel by lazy { ApartamentoDetailViewModel(getApartamentoUseCase, getMoradoresForApartamentoUseCase, removeMoradorUseCase) }
 
     @BeforeTest
     fun setup() {
@@ -108,5 +112,99 @@ class ApartamentoDetailViewModelTest : TestsWithMocks() {
         assertFalse(viewModel.uiState.value.isError)
         assertEquals(1, viewModel.uiState.value.moradores.size)
         assertEquals("p-1", viewModel.uiState.value.moradores.first().pessoaId)
+    }
+
+    @Test
+    fun `GIVEN successful load WHEN load THEN moradores have apartamentoId`() = runTest(testScheduler) {
+        val apt = Apartamento(id = "apt-1", numero = "101", andar = "1", moradores = emptyList())
+        val moradores = listOf(
+            Morador(
+                pessoa = Pessoa(id = "p-1", cpf = "12345678901", nome = "Joao", email = "", telefone = ""),
+                apartamento = apt,
+                tipo = MoradorTipo.RESIDENTE
+            )
+        )
+        everySuspending { apartamentosRepository.getApartamento("apt-1") } returns Result.success(apt)
+        everySuspending { moradoresRepository.getMoradoresForApartamento("apt-1") } returns Result.success(moradores)
+
+        viewModel.setApartamentoId("apt-1")
+        viewModel.load()
+        advanceUntilIdle()
+
+        assertEquals("apt-1", viewModel.uiState.value.moradores.first().apartamentoId)
+    }
+
+    // --- Delete flow ---
+
+    @Test
+    fun `WHEN onDeleteMoradorClick THEN showDeleteConfirmation is set`() = runTest(testScheduler) {
+        loadMoradores()
+
+        val morador = viewModel.uiState.value.moradores.first()
+        viewModel.onDeleteMoradorClick(morador)
+
+        assertNotNull(viewModel.uiState.value.showDeleteConfirmation)
+        assertEquals(morador.pessoaId, viewModel.uiState.value.showDeleteConfirmation?.pessoaId)
+    }
+
+    @Test
+    fun `WHEN onDismissDeleteMorador THEN showDeleteConfirmation is cleared`() = runTest(testScheduler) {
+        loadMoradores()
+
+        viewModel.onDeleteMoradorClick(viewModel.uiState.value.moradores.first())
+        viewModel.onDismissDeleteMorador()
+
+        assertNull(viewModel.uiState.value.showDeleteConfirmation)
+    }
+
+    @Test
+    fun `GIVEN delete succeeds WHEN onConfirmDeleteMorador THEN list is refreshed`() = runTest(testScheduler) {
+        val apt = Apartamento(id = "apt-1", numero = "101", andar = "1", moradores = emptyList())
+        val moradores = listOf(
+            Morador(
+                pessoa = Pessoa(id = "p-1", cpf = "12345678901", nome = "Joao", email = "", telefone = ""),
+                apartamento = apt,
+                tipo = MoradorTipo.RESIDENTE
+            )
+        )
+
+        everySuspending { apartamentosRepository.getApartamento("apt-1") } returns Result.success(apt)
+        var moradoresResponse: Result<List<Morador>> = Result.success(moradores)
+        everySuspending { moradoresRepository.getMoradoresForApartamento("apt-1") } runs { moradoresResponse }
+
+        viewModel.setApartamentoId("apt-1")
+        viewModel.load()
+        advanceUntilIdle()
+
+        val morador = viewModel.uiState.value.moradores.first()
+        viewModel.onDeleteMoradorClick(morador)
+
+        everySuspending { moradoresRepository.removeMorador("p-1", "apt-1") } returns Result.success(Unit)
+        moradoresResponse = Result.success(emptyList())
+
+        viewModel.onConfirmDeleteMorador()
+        advanceUntilIdle()
+
+        assertNull(viewModel.uiState.value.showDeleteConfirmation)
+        assertTrue(viewModel.uiState.value.moradores.isEmpty())
+    }
+
+    // --- Helpers ---
+
+    private suspend fun loadMoradores() {
+        val apt = Apartamento(id = "apt-1", numero = "101", andar = "1", moradores = emptyList())
+        val moradores = listOf(
+            Morador(
+                pessoa = Pessoa(id = "p-1", cpf = "12345678901", nome = "Joao", email = "", telefone = ""),
+                apartamento = apt,
+                tipo = MoradorTipo.RESIDENTE
+            )
+        )
+        everySuspending { apartamentosRepository.getApartamento("apt-1") } returns Result.success(apt)
+        everySuspending { moradoresRepository.getMoradoresForApartamento("apt-1") } returns Result.success(moradores)
+
+        viewModel.setApartamentoId("apt-1")
+        viewModel.load()
+        testScheduler.advanceUntilIdle()
     }
 }

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/moradores/MoradorInfoViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/moradores/MoradorInfoViewModelTest.kt
@@ -2,9 +2,11 @@ package com.zalamena.condominios.ui.moradores
 
 import com.zalamena.condominios.condominio.domain.apartamento.models.Apartamento
 import com.zalamena.condominios.condominio.domain.morador.model.Morador
+import com.zalamena.condominios.condominio.domain.morador.model.MoradorException
 import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
 import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
 import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradorDetailUseCase
+import com.zalamena.condominios.condominio.domain.morador.usecase.UpdateMoradorTipoUseCaseImpl
 import com.zalamena.condominios.condominio.ui.moradores.details.MoradorInfoViewModel
 import com.zalamena.condominios.pessoa.domain.models.Pessoa
 import kotlinx.coroutines.Dispatchers
@@ -37,7 +39,8 @@ class MoradorInfoViewModelTest : TestsWithMocks() {
     private val testDispatcher = UnconfinedTestDispatcher(testScheduler)
 
     private val getMoradorDetailUseCase by lazy { GetMoradorDetailUseCase(moradoresRepository) }
-    private val viewModel by lazy { MoradorInfoViewModel(getMoradorDetailUseCase) }
+    private val updateMoradorTipoUseCase by lazy { UpdateMoradorTipoUseCaseImpl(moradoresRepository) }
+    private val viewModel by lazy { MoradorInfoViewModel(getMoradorDetailUseCase, updateMoradorTipoUseCase) }
 
     @BeforeTest
     fun setup() {
@@ -106,6 +109,21 @@ class MoradorInfoViewModelTest : TestsWithMocks() {
         assertEquals(2, apts.size)
         assertEquals("101", apts[0].numero)
         assertEquals("202", apts[1].numero)
+    }
+
+    @Test
+    fun `GIVEN moradores exist WHEN load THEN apartamentos include tipo`() = runTest(testScheduler) {
+        val pessoa = Pessoa(id = "p1", cpf = "12345678901", nome = "Joao", email = "j@t.com", telefone = "119")
+        val moradores = listOf(
+            Morador(pessoa = pessoa, apartamento = Apartamento("apt-1", "101", "1", emptyList()), tipo = MoradorTipo.PROPRIETARIO)
+        )
+        everySuspending { moradoresRepository.getMoradoresForPessoa("p1") } returns Result.success(moradores)
+
+        viewModel.setPessoaId("p1")
+        viewModel.load()
+        advanceUntilIdle()
+
+        assertEquals(MoradorTipo.PROPRIETARIO, viewModel.uiState.value.apartamentos.first().tipo)
     }
 
     // --- Missing info ---
@@ -195,5 +213,61 @@ class MoradorInfoViewModelTest : TestsWithMocks() {
         viewModel.onNavigationHandled()
 
         assertNull(viewModel.uiState.value.navigationEvent)
+    }
+
+    // --- Admin mode ---
+
+    @Test
+    fun `WHEN setAdminMode true THEN isAdminMode is true`() = runTest(testScheduler) {
+        assertFalse(viewModel.uiState.value.isAdminMode)
+
+        viewModel.setAdminMode(true)
+
+        assertTrue(viewModel.uiState.value.isAdminMode)
+    }
+
+    // --- Edit tipo ---
+
+    @Test
+    fun `GIVEN save tipo succeeds WHEN onSaveTipo THEN reloads and clears error`() = runTest(testScheduler) {
+        val pessoa = Pessoa(id = "p1", cpf = "12345678901", nome = "Joao", email = "j@t.com", telefone = "119")
+        val moradores = listOf(
+            Morador(pessoa = pessoa, apartamento = Apartamento("apt-1", "101", "1", emptyList()), tipo = MoradorTipo.RESIDENTE)
+        )
+        everySuspending { moradoresRepository.getMoradoresForPessoa("p1") } returns Result.success(moradores)
+        everySuspending { moradoresRepository.updateMoradorTipo("p1", "apt-1", MoradorTipo.PROPRIETARIO) } returns Result.success(Unit)
+        everySuspending { moradoresRepository.getMoradoresForApartamento("apt-1") } returns Result.success(emptyList())
+
+        viewModel.setPessoaId("p1")
+        viewModel.load()
+        advanceUntilIdle()
+
+        viewModel.onSaveTipo("apt-1", MoradorTipo.PROPRIETARIO)
+        advanceUntilIdle()
+
+        assertNull(viewModel.uiState.value.tipoError)
+    }
+
+    @Test
+    fun `GIVEN PROPRIETARIO limit reached WHEN onSaveTipo THEN sets tipoError`() = runTest(testScheduler) {
+        val pessoa = Pessoa(id = "p1", cpf = "12345678901", nome = "Joao", email = "j@t.com", telefone = "119")
+        val moradores = listOf(
+            Morador(pessoa = pessoa, apartamento = Apartamento("apt-1", "101", "1", emptyList()), tipo = MoradorTipo.RESIDENTE)
+        )
+        val existingProprietarios = listOf(
+            Morador.dummy.copy(pessoa = Pessoa.dummy.copy(id = "other-1"), tipo = MoradorTipo.PROPRIETARIO),
+            Morador.dummy.copy(pessoa = Pessoa.dummy.copy(id = "other-2"), tipo = MoradorTipo.PROPRIETARIO)
+        )
+        everySuspending { moradoresRepository.getMoradoresForPessoa("p1") } returns Result.success(moradores)
+        everySuspending { moradoresRepository.getMoradoresForApartamento("apt-1") } returns Result.success(existingProprietarios)
+
+        viewModel.setPessoaId("p1")
+        viewModel.load()
+        advanceUntilIdle()
+
+        viewModel.onSaveTipo("apt-1", MoradorTipo.PROPRIETARIO)
+        advanceUntilIdle()
+
+        assertEquals("Limite de 2 proprietarios por apartamento atingido", viewModel.uiState.value.tipoError)
     }
 }

--- a/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
+++ b/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
@@ -21,6 +21,10 @@ import com.zalamena.condominios.condominio.domain.morador.usecase.AddMoradorUseC
 import com.zalamena.condominios.condominio.domain.morador.usecase.AddMoradorUseCaseImpl
 import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradorDetailUseCase
 import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradoresForApartamentoUseCase
+import com.zalamena.condominios.condominio.domain.morador.usecase.RemoveMoradorUseCase
+import com.zalamena.condominios.condominio.domain.morador.usecase.RemoveMoradorUseCaseImpl
+import com.zalamena.condominios.condominio.domain.morador.usecase.UpdateMoradorTipoUseCase
+import com.zalamena.condominios.condominio.domain.morador.usecase.UpdateMoradorTipoUseCaseImpl
 import com.zalamena.condominios.condominio.ui.adminhome.AdminHomeViewModel
 import com.zalamena.condominios.condominio.ui.addapartamento.AddApartamentoViewModel
 import com.zalamena.condominios.condominio.ui.addcondominio.AddCondominioViewModel
@@ -137,6 +141,8 @@ val useCaseModule = module {
     factory<AddMoradorUseCase> { AddMoradorUseCaseImpl(get()) }
     factory { GetMoradoresForApartamentoUseCase(get()) }
     factory { GetMoradorDetailUseCase(get()) }
+    factory<RemoveMoradorUseCase> { RemoveMoradorUseCaseImpl(get()) }
+    factory<UpdateMoradorTipoUseCase> { UpdateMoradorTipoUseCaseImpl(get()) }
     factory { CreateUserUseCase(get(), get()) }
     factory { GetPorteirosByCondominioUseCase(get()) }
     factory { DeletePorteiroUseCase(get()) }


### PR DESCRIPTION
## Summary
- Admin can remove moradores from apartments with confirmation dialog
- Admin can edit morador tipo (Proprietário/Morador/Temporário) from morador detail screen
- PROPRIETARIO max-2 business rule enforced on tipo changes with error message
- Fix stale data flash when switching between apartment details (reset state on navigation)
- New use cases: `RemoveMoradorUseCase`, `UpdateMoradorTipoUseCase`
- 10+ new domain and ViewModel tests

Closes #9

## Test plan
- [ ] Open apartment detail as admin → each morador has "Excluir" button
- [ ] Tap "Excluir" → confirmation dialog appears
- [ ] Cancel → morador stays, dialog closes
- [ ] Confirm → morador removed, list refreshes immediately
- [ ] Tap morador → detail screen shows tipo dropdown per apartment (admin only)
- [ ] Change tipo and tap "Salvar" → tipo updates immediately
- [ ] Try setting 3rd PROPRIETARIO → error message shown, tipo reverts
- [ ] Doorman mode → no "Excluir" button, no tipo dropdown (read-only)
- [ ] Navigate between different apartments → no stale data flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)