### PR TITLE
Add morador user account creation (#29)

### DIFF
--- a/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/apartamento/dao/ApartamentoDao.kt
+++ b/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/apartamento/dao/ApartamentoDao.kt
@@ -21,4 +21,7 @@ interface ApartamentoDao {
 
     @Insert
     suspend fun addApartamento(apartamento: ApartamentoEntity)
+
+    @Query("SELECT condominioId FROM Apartamento WHERE id = :apartamentoId")
+    suspend fun getCondominioIdForApartamento(apartamentoId: String): String?
 }

--- a/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/apartamento/repository/ApartamentoRepositoryImpl.kt
+++ b/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/apartamento/repository/ApartamentoRepositoryImpl.kt
@@ -31,6 +31,10 @@ class ApartamentoRepositoryImpl(
         }
     }
 
+    override suspend fun getCondominioIdForApartamento(apartamentoId: String): String? {
+        return apartamentoDao.getCondominioIdForApartamento(apartamentoId)
+    }
+
     private suspend fun generateApartamentoId(numeroApartamento: String): String {
         return "${apartamentoDao.getApartamentos().size}-${numeroApartamento}"
     }

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/apartamento/repository/ApartamentosRepository.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/apartamento/repository/ApartamentosRepository.kt
@@ -9,4 +9,6 @@ interface ApartamentosRepository {
     suspend fun getApartamentos(): Result<List<Apartamento>>
 
     suspend fun addApartamento(condominioId: String, apartamento: Apartamento): Result<String>
+
+    suspend fun getCondominioIdForApartamento(apartamentoId: String): String?
 }

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/repository/MoradorAccountCreator.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/repository/MoradorAccountCreator.kt
@@ -1,0 +1,9 @@
+package com.zalamena.condominios.condominio.domain.morador.repository
+
+/**
+ * Cross-module interface to create a user account for a morador.
+ * Returns Result.success(email) on success, or Result.failure with the error.
+ */
+fun interface MoradorAccountCreator {
+    suspend fun createAccount(pessoaId: String, email: String, password: String): Result<String>
+}

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/repository/MoradorAccountProvider.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/morador/repository/MoradorAccountProvider.kt
@@ -1,0 +1,9 @@
+package com.zalamena.condominios.condominio.domain.morador.repository
+
+/**
+ * Cross-module interface to check if a morador has a user account.
+ * Returns the account email if one exists, or null if the morador has no account.
+ */
+fun interface MoradorAccountProvider {
+    suspend fun getAccountEmailForPessoa(pessoaId: String): String?
+}

--- a/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/apartamento/ApartamentoFlowIntegrationTest.kt
+++ b/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/apartamento/ApartamentoFlowIntegrationTest.kt
@@ -37,6 +37,9 @@ class ApartamentoFlowIntegrationTest {
                 apartamentosStorage.add(condominioId to apartamento.copy(id = id))
                 id
             }
+
+        override suspend fun getCondominioIdForApartamento(apartamentoId: String): String? =
+            apartamentosStorage.find { (_, apt) -> apt.id == apartamentoId }?.first
     }
 
     private val fakeCondominioRepository = object : CondominioRepository {

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoScreen.kt
@@ -10,19 +10,22 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material.icons.filled.MeetingRoom
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
@@ -31,9 +34,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -72,6 +77,21 @@ fun MoradorInfoScreen(
         }
     }
 
+    if (uiState.showCreateAccountDialog) {
+        CreateAccountDialog(
+            email = uiState.createAccountEmail,
+            password = uiState.createAccountPassword,
+            emailError = uiState.createAccountEmailError,
+            passwordError = uiState.createAccountPasswordError,
+            generalError = uiState.createAccountError,
+            isLoading = uiState.isCreatingAccount,
+            onEmailChanged = viewModel::onCreateAccountEmailChanged,
+            onPasswordChanged = viewModel::onCreateAccountPasswordChanged,
+            onConfirm = viewModel::onCreateAccount,
+            onDismiss = viewModel::onDismissCreateAccountDialog
+        )
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -105,7 +125,8 @@ fun MoradorInfoScreen(
                         uiState = uiState,
                         isAdminMode = isAdminMode,
                         onApartamentoClick = viewModel::onApartamentoClick,
-                        onSaveTipo = viewModel::onSaveTipo
+                        onSaveTipo = viewModel::onSaveTipo,
+                        onCreateAccount = viewModel::onShowCreateAccountDialog
                     )
                 }
             }
@@ -118,7 +139,8 @@ private fun MoradorDetailContent(
     uiState: MoradorDetailUiState,
     isAdminMode: Boolean,
     onApartamentoClick: (apartamentoId: String) -> Unit,
-    onSaveTipo: (apartamentoId: String, newTipo: MoradorTipo) -> Unit
+    onSaveTipo: (apartamentoId: String, newTipo: MoradorTipo) -> Unit,
+    onCreateAccount: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -149,6 +171,63 @@ private fun MoradorDetailContent(
             )
             Spacer(Modifier.width(8.dp))
             Text(uiState.telefone, style = MaterialTheme.typography.bodyMedium)
+        }
+
+        // Account section (admin mode only)
+        if (isAdminMode) {
+            Spacer(Modifier.height(16.dp))
+            HorizontalDivider()
+            Spacer(Modifier.height(12.dp))
+
+            Text("Conta de Acesso", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(8.dp))
+
+            if (uiState.accountEmail != null) {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            Icons.Default.AccountCircle,
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                            tint = MaterialTheme.colorScheme.onSecondaryContainer
+                        )
+                        Spacer(Modifier.width(12.dp))
+                        Column {
+                            Text(
+                                "Conta ativa",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer
+                            )
+                            Text(
+                                uiState.accountEmail,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer
+                            )
+                        }
+                    }
+                }
+            } else {
+                OutlinedButton(
+                    onClick = onCreateAccount,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(
+                        Icons.Default.AccountCircle,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text("Criar conta de acesso")
+                }
+            }
         }
 
         Spacer(Modifier.height(16.dp))
@@ -182,6 +261,83 @@ private fun MoradorDetailContent(
             }
         }
     }
+}
+
+@Composable
+private fun CreateAccountDialog(
+    email: String,
+    password: String,
+    emailError: String?,
+    passwordError: String?,
+    generalError: String?,
+    isLoading: Boolean,
+    onEmailChanged: (String) -> Unit,
+    onPasswordChanged: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = { if (!isLoading) onDismiss() },
+        title = { Text("Criar conta de acesso") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    "Informe o email e uma senha temporaria para o morador.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+
+                OutlinedTextField(
+                    value = email,
+                    onValueChange = onEmailChanged,
+                    label = { Text("Email") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    isError = emailError != null,
+                    supportingText = { emailError?.let { Text(it) } },
+                    enabled = !isLoading
+                )
+
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = onPasswordChanged,
+                    label = { Text("Senha temporaria") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    isError = passwordError != null,
+                    supportingText = { passwordError?.let { Text(it) } },
+                    enabled = !isLoading
+                )
+
+                generalError?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                enabled = !isLoading
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                } else {
+                    Text("Criar")
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                enabled = !isLoading
+            ) {
+                Text("Cancelar")
+            }
+        }
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zalamena.condominios.condominio.domain.morador.model.MoradorException
 import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradorAccountCreator
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradorAccountProvider
 import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradorDetailUseCase
 import com.zalamena.condominios.condominio.domain.morador.usecase.UpdateMoradorTipoUseCase
 import com.zalamena.condominios.condominio.ui.apartamento.detail.models.maskCpf
@@ -37,12 +39,24 @@ data class MoradorDetailUiState(
     val isError: Boolean = false,
     val navigationEvent: MoradorInfoNavigationEvent? = null,
     val isAdminMode: Boolean = false,
-    val tipoError: String? = null
+    val tipoError: String? = null,
+    // Account-related state
+    val accountEmail: String? = null,
+    val showCreateAccountDialog: Boolean = false,
+    val createAccountEmail: String = "",
+    val createAccountPassword: String = "",
+    val createAccountEmailError: String? = null,
+    val createAccountPasswordError: String? = null,
+    val createAccountError: String? = null,
+    val isCreatingAccount: Boolean = false,
+    val accountCreatedSuccess: Boolean = false
 )
 
 class MoradorInfoViewModel(
     private val getMoradorDetailUseCase: GetMoradorDetailUseCase,
-    private val updateMoradorTipoUseCase: UpdateMoradorTipoUseCase
+    private val updateMoradorTipoUseCase: UpdateMoradorTipoUseCase,
+    private val moradorAccountProvider: MoradorAccountProvider,
+    private val moradorAccountCreator: MoradorAccountCreator
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MoradorDetailUiState())
@@ -95,7 +109,15 @@ class MoradorInfoViewModel(
                 .onFailure {
                     _uiState.update { it.copy(isLoading = false, isError = true) }
                 }
+
+            // Load account info
+            loadAccountInfo()
         }
+    }
+
+    private suspend fun loadAccountInfo() {
+        val email = moradorAccountProvider.getAccountEmailForPessoa(pessoaId)
+        _uiState.update { it.copy(accountEmail = email) }
     }
 
     fun onApartamentoClick(apartamentoId: String) {
@@ -124,6 +146,90 @@ class MoradorInfoViewModel(
                 .onFailure { error ->
                     if (error is MoradorException.MaxProprietariosExceededException) {
                         _uiState.update { it.copy(tipoError = "Limite de 2 proprietarios por apartamento atingido") }
+                    }
+                }
+        }
+    }
+
+    // Account creation methods
+
+    fun onShowCreateAccountDialog() {
+        _uiState.update {
+            it.copy(
+                showCreateAccountDialog = true,
+                createAccountEmail = "",
+                createAccountPassword = "",
+                createAccountEmailError = null,
+                createAccountPasswordError = null,
+                createAccountError = null,
+                accountCreatedSuccess = false
+            )
+        }
+    }
+
+    fun onDismissCreateAccountDialog() {
+        _uiState.update {
+            it.copy(
+                showCreateAccountDialog = false,
+                createAccountEmail = "",
+                createAccountPassword = "",
+                createAccountEmailError = null,
+                createAccountPasswordError = null,
+                createAccountError = null,
+                accountCreatedSuccess = false
+            )
+        }
+    }
+
+    fun onCreateAccountEmailChanged(email: String) {
+        _uiState.update { it.copy(createAccountEmail = email, createAccountEmailError = null, createAccountError = null) }
+    }
+
+    fun onCreateAccountPasswordChanged(password: String) {
+        _uiState.update { it.copy(createAccountPassword = password, createAccountPasswordError = null, createAccountError = null) }
+    }
+
+    fun onCreateAccount() {
+        val state = _uiState.value
+        if (pessoaId.isBlank()) return
+
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    isCreatingAccount = true,
+                    createAccountEmailError = null,
+                    createAccountPasswordError = null,
+                    createAccountError = null
+                )
+            }
+
+            moradorAccountCreator.createAccount(
+                pessoaId = pessoaId,
+                email = state.createAccountEmail,
+                password = state.createAccountPassword
+            )
+                .onSuccess { email ->
+                    _uiState.update {
+                        it.copy(
+                            isCreatingAccount = false,
+                            accountCreatedSuccess = true,
+                            accountEmail = email,
+                            showCreateAccountDialog = false
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    val message = error.message ?: "Erro ao criar conta"
+                    // Map known error messages to specific fields
+                    when {
+                        message.contains("Email") && (message.contains("obrigat") || message.contains("conter @")) ->
+                            _uiState.update { it.copy(isCreatingAccount = false, createAccountEmailError = message) }
+                        message.contains("email") && message.contains("uso") ->
+                            _uiState.update { it.copy(isCreatingAccount = false, createAccountEmailError = message) }
+                        message.contains("Senha") ->
+                            _uiState.update { it.copy(isCreatingAccount = false, createAccountPasswordError = message) }
+                        else ->
+                            _uiState.update { it.copy(isCreatingAccount = false, createAccountError = message) }
                     }
                 }
         }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/moradores/details/MoradorInfoViewModel.kt
@@ -154,10 +154,12 @@ class MoradorInfoViewModel(
     // Account creation methods
 
     fun onShowCreateAccountDialog() {
+        val currentEmail = _uiState.value.email
+        val prefillEmail = if (currentEmail != "Nao informado") currentEmail else ""
         _uiState.update {
             it.copy(
                 showCreateAccountDialog = true,
-                createAccountEmail = "",
+                createAccountEmail = prefillEmail,
                 createAccountPassword = "",
                 createAccountEmailError = null,
                 createAccountPasswordError = null,

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/moradores/MoradorInfoViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/moradores/MoradorInfoViewModelTest.kt
@@ -4,6 +4,8 @@ import com.zalamena.condominios.condominio.domain.apartamento.models.Apartamento
 import com.zalamena.condominios.condominio.domain.morador.model.Morador
 import com.zalamena.condominios.condominio.domain.morador.model.MoradorException
 import com.zalamena.condominios.condominio.domain.morador.model.MoradorTipo
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradorAccountCreator
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradorAccountProvider
 import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
 import com.zalamena.condominios.condominio.domain.morador.usecase.GetMoradorDetailUseCase
 import com.zalamena.condominios.condominio.domain.morador.usecase.UpdateMoradorTipoUseCaseImpl
@@ -40,7 +42,9 @@ class MoradorInfoViewModelTest : TestsWithMocks() {
 
     private val getMoradorDetailUseCase by lazy { GetMoradorDetailUseCase(moradoresRepository) }
     private val updateMoradorTipoUseCase by lazy { UpdateMoradorTipoUseCaseImpl(moradoresRepository) }
-    private val viewModel by lazy { MoradorInfoViewModel(getMoradorDetailUseCase, updateMoradorTipoUseCase) }
+    private val noOpAccountProvider = MoradorAccountProvider { null }
+    private val noOpAccountCreator = MoradorAccountCreator { _, _, _ -> Result.failure(UnsupportedOperationException()) }
+    private val viewModel by lazy { MoradorInfoViewModel(getMoradorDetailUseCase, updateMoradorTipoUseCase, noOpAccountProvider, noOpAccountCreator) }
 
     @BeforeTest
     fun setup() {

--- a/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
+++ b/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
@@ -17,6 +17,8 @@ import com.zalamena.condominios.condominio.domain.condominio.usecase.GetCondomin
 import com.zalamena.condominios.condominio.domain.condominio.usecase.GetCondominiosUseCase
 import com.zalamena.condominios.condominio.domain.condominio.usecase.GetMoradoresUseCase
 import com.zalamena.condominios.condominio.domain.morador.repository.MoradoresRepository
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradorAccountCreator
+import com.zalamena.condominios.condominio.domain.morador.repository.MoradorAccountProvider
 import com.zalamena.condominios.condominio.domain.morador.repository.PessoaProvider
 import com.zalamena.condominios.condominio.domain.morador.usecase.AddMoradorUseCase
 import com.zalamena.condominios.condominio.domain.morador.usecase.AddMoradorUseCaseImpl
@@ -70,7 +72,10 @@ import com.zalamena.login.data.repository.UserRepositoryImpl
 import com.zalamena.login.domain.repository.LoginRepository
 import com.zalamena.login.domain.repository.CondominioValidator
 import com.zalamena.login.domain.repository.UserRepository
+import com.zalamena.login.domain.repository.MoradorValidator
+import com.zalamena.login.domain.usecase.CreateMoradorAccountUseCase
 import com.zalamena.login.domain.usecase.CreateUserUseCase
+import com.zalamena.login.domain.usecase.GetMoradorAccountUseCase
 import com.zalamena.login.domain.usecase.LoginUseCase
 import com.zalamena.login.domain.usecase.LogoutUseCase
 import com.zalamena.login.ui.LoginViewModel
@@ -138,7 +143,7 @@ val repositoryModule = module {
     single<PorteiroProvider> {
         PorteiroProvider { condominioId ->
             get<UserRepository>().getUsersByCondominioId(condominioId).map { users ->
-                users.map { user ->
+                users.filter { it.role is UserRole.Porteiro }.map { user ->
                     PorteiroInfo(
                         id = user.id,
                         name = user.name,
@@ -163,6 +168,25 @@ val repositoryModule = module {
     single<PessoaProvider> {
         PessoaProvider { get<GetPessoasListUseCase>().invoke() }
     }
+    single<MoradorValidator> {
+        MoradorValidator { pessoaId ->
+            val moradores = get<MoradoresRepository>().getMoradoresForPessoa(pessoaId).getOrNull()
+            moradores?.firstOrNull()?.apartamento?.let { apt ->
+                // Get the condominioId by looking up the apartamento's condominio
+                get<ApartamentosRepository>().getCondominioIdForApartamento(apt.id)
+            }
+        }
+    }
+    single<MoradorAccountProvider> {
+        MoradorAccountProvider { pessoaId ->
+            get<UserRepository>().getUserByPessoaId(pessoaId).getOrNull()?.email
+        }
+    }
+    single<MoradorAccountCreator> {
+        MoradorAccountCreator { pessoaId, email, password ->
+            get<CreateMoradorAccountUseCase>().invoke(pessoaId, email, password).map { it.email }
+        }
+    }
 }
 
 val useCaseModule = module {
@@ -185,6 +209,8 @@ val useCaseModule = module {
     factory<RemoveMoradorUseCase> { RemoveMoradorUseCaseImpl(get()) }
     factory<UpdateMoradorTipoUseCase> { UpdateMoradorTipoUseCaseImpl(get()) }
     factory { CreateUserUseCase(get(), get()) }
+    factory { CreateMoradorAccountUseCase(get(), get()) }
+    factory { GetMoradorAccountUseCase(get()) }
     factory { GetPorteirosByCondominioUseCase(get()) }
     factory { DeletePorteiroUseCase(get()) }
     factory { ReassignPorteiroUseCase(get(), get()) }

--- a/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/api/FakeLoginApi.kt
+++ b/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/api/FakeLoginApi.kt
@@ -48,7 +48,13 @@ class FakeLoginApi(
 
         val condominioId = when (val role = user.role) {
             is UserRole.Porteiro -> role.condominioId
+            is UserRole.Morador -> role.condominioId
             is UserRole.Admin -> null
+        }
+
+        val pessoaId = when (val role = user.role) {
+            is UserRole.Morador -> role.pessoaId
+            else -> null
         }
 
         return UserDto(
@@ -58,8 +64,10 @@ class FakeLoginApi(
             role = when (user.role) {
                 is UserRole.Admin -> "ADMIN"
                 is UserRole.Porteiro -> "PORTEIRO"
+                is UserRole.Morador -> "MORADOR"
             },
-            condominioId = condominioId
+            condominioId = condominioId,
+            pessoaId = pessoaId
         )
     }
 }

--- a/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/mapper/LoginMapper.kt
+++ b/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/mapper/LoginMapper.kt
@@ -9,6 +9,10 @@ fun UserDto.toDomain(): User {
     val userRole = when (role.uppercase()) {
         "ADMIN" -> UserRole.Admin
         "PORTEIRO" -> UserRole.Porteiro(condominioId = condominioId ?: "")
+        "MORADOR" -> UserRole.Morador(
+            pessoaId = pessoaId ?: "",
+            condominioId = condominioId ?: ""
+        )
         else -> throw IllegalArgumentException("Unknown role: $role")
     }
     return User(

--- a/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/models/UserDto.kt
+++ b/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/models/UserDto.kt
@@ -5,5 +5,6 @@ data class UserDto(
     val cpf: String,
     val email: String,
     val role: String,
-    val condominioId: String? = null
+    val condominioId: String? = null,
+    val pessoaId: String? = null
 )

--- a/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/repository/LoginRepositoryImpl.kt
+++ b/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/repository/LoginRepositoryImpl.kt
@@ -22,6 +22,11 @@ class LoginRepositoryImpl (
                 val condominioId = sessionRepository.getCondominioId() ?: ""
                 UserRole.Porteiro(condominioId)
             }
+            "MORADOR" -> {
+                val condominioId = sessionRepository.getCondominioId() ?: ""
+                val pessoaId = sessionRepository.getPessoaId() ?: ""
+                UserRole.Morador(pessoaId = pessoaId, condominioId = condominioId)
+            }
             else -> null
         }
     }
@@ -44,6 +49,10 @@ class LoginRepositoryImpl (
 
             if (userResult.condominioId != null) {
                 sessionRepository.saveCondominioId(userResult.condominioId)
+            }
+
+            if (userResult.pessoaId != null) {
+                sessionRepository.savePessoaId(userResult.pessoaId)
             }
 
             Result.success(userResult.toDomain())

--- a/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/repository/SessionRepository.kt
+++ b/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/repository/SessionRepository.kt
@@ -7,5 +7,7 @@ interface SessionRepository {
     suspend fun getRole(): String?
     suspend fun saveCondominioId(condominioId: String)
     suspend fun getCondominioId(): String?
+    suspend fun savePessoaId(pessoaId: String)
+    suspend fun getPessoaId(): String?
     suspend fun clearSession()
 }

--- a/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/repository/SessionRepositoryImpl.kt
+++ b/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/repository/SessionRepositoryImpl.kt
@@ -6,6 +6,7 @@ class SessionRepositoryImpl : SessionRepository {
     private var expiresIn: Long = 0L
     private var role: String? = null
     private var condominioId: String? = null
+    private var pessoaId: String? = null
 
     override suspend fun saveSession(authToken: String, expiresIn: Long, role: String) {
         token = authToken
@@ -27,10 +28,17 @@ class SessionRepositoryImpl : SessionRepository {
 
     override suspend fun getCondominioId(): String? = condominioId
 
+    override suspend fun savePessoaId(pessoaId: String) {
+        this.pessoaId = pessoaId
+    }
+
+    override suspend fun getPessoaId(): String? = pessoaId
+
     override suspend fun clearSession() {
         token = null
         expiresIn = 0L
         role = null
         condominioId = null
+        pessoaId = null
     }
 }

--- a/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/repository/UserRepositoryImpl.kt
+++ b/features/login/data/src/commonMain/kotlin/com/zalamena/login/data/repository/UserRepositoryImpl.kt
@@ -53,8 +53,11 @@ class UserRepositoryImpl : UserRepository {
     override suspend fun getUsersByCondominioId(condominioId: String): Result<List<User>> {
         return try {
             val filtered = users.filter { user ->
-                val role = user.role
-                role is UserRole.Porteiro && role.condominioId == condominioId
+                when (val role = user.role) {
+                    is UserRole.Porteiro -> role.condominioId == condominioId
+                    is UserRole.Morador -> role.condominioId == condominioId
+                    else -> false
+                }
             }
             Result.success(filtered)
         } catch (e: Exception) {
@@ -84,6 +87,18 @@ class UserRepositoryImpl : UserRepository {
                 users[index] = users[index].copy(role = newRole)
                 Result.success(Unit)
             }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getUserByPessoaId(pessoaId: String): Result<User?> {
+        return try {
+            val user = users.find { user ->
+                val role = user.role
+                role is UserRole.Morador && role.pessoaId == pessoaId
+            }
+            Result.success(user)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/models/UserRole.kt
+++ b/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/models/UserRole.kt
@@ -3,4 +3,5 @@ package com.zalamena.login.domain.models
 sealed class UserRole {
     data object Admin : UserRole()
     data class Porteiro(val condominioId: String) : UserRole()
+    data class Morador(val pessoaId: String, val condominioId: String) : UserRole()
 }

--- a/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/repository/MoradorValidator.kt
+++ b/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/repository/MoradorValidator.kt
@@ -1,0 +1,12 @@
+package com.zalamena.login.domain.repository
+
+/**
+ * Cross-module interface to validate a pessoa is a morador and retrieve their condominioId.
+ * Implemented in DI using the condominio module's repository.
+ */
+fun interface MoradorValidator {
+    /**
+     * Returns the condominioId if the pessoa is a morador, or null if not found.
+     */
+    suspend fun getCondominioIdForMorador(pessoaId: String): String?
+}

--- a/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/repository/UserRepository.kt
+++ b/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/repository/UserRepository.kt
@@ -22,4 +22,6 @@ interface UserRepository {
     suspend fun updateUserRole(userId: String, newRole: UserRole): Result<Unit>
 
     suspend fun authenticate(email: String, password: String): Result<User>
+
+    suspend fun getUserByPessoaId(pessoaId: String): Result<User?>
 }

--- a/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/usecase/CreateMoradorAccountUseCase.kt
+++ b/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/usecase/CreateMoradorAccountUseCase.kt
@@ -1,0 +1,58 @@
+package com.zalamena.login.domain.usecase
+
+import com.zalamena.login.domain.models.User
+import com.zalamena.login.domain.models.UserRole
+import com.zalamena.login.domain.repository.MoradorValidator
+import com.zalamena.login.domain.repository.UserRepository
+
+sealed class CreateMoradorAccountError(override val message: String) : Exception(message) {
+    object EmptyEmail : CreateMoradorAccountError("Email é obrigatório")
+    object InvalidEmail : CreateMoradorAccountError("Email deve conter @")
+    object EmptyPassword : CreateMoradorAccountError("Senha é obrigatória")
+    object EmailAlreadyTaken : CreateMoradorAccountError("Este email já está em uso")
+    object MoradorNotFound : CreateMoradorAccountError("Pessoa não é um morador em nenhum apartamento")
+    object AccountAlreadyExists : CreateMoradorAccountError("Este morador já possui uma conta")
+}
+
+class CreateMoradorAccountUseCase(
+    private val userRepository: UserRepository,
+    private val moradorValidator: MoradorValidator
+) {
+
+    suspend operator fun invoke(
+        pessoaId: String,
+        email: String,
+        password: String
+    ): Result<User> {
+        val trimmedEmail = email.trim()
+        val trimmedPassword = password.trim()
+
+        if (trimmedEmail.isBlank()) return Result.failure(CreateMoradorAccountError.EmptyEmail)
+        if (!trimmedEmail.contains("@")) return Result.failure(CreateMoradorAccountError.InvalidEmail)
+        if (trimmedPassword.isBlank()) return Result.failure(CreateMoradorAccountError.EmptyPassword)
+
+        // Check if this morador already has an account
+        val existingUsers = userRepository.getUsers().getOrElse { emptyList() }
+        val alreadyHasAccount = existingUsers.any { user ->
+            val role = user.role
+            role is UserRole.Morador && role.pessoaId == pessoaId
+        }
+        if (alreadyHasAccount) return Result.failure(CreateMoradorAccountError.AccountAlreadyExists)
+
+        // Check email uniqueness
+        val emailTaken = existingUsers.any { it.email.equals(trimmedEmail, ignoreCase = true) }
+        if (emailTaken) return Result.failure(CreateMoradorAccountError.EmailAlreadyTaken)
+
+        // Validate the pessoa is a morador and get their condominioId
+        val condominioId = moradorValidator.getCondominioIdForMorador(pessoaId)
+            ?: return Result.failure(CreateMoradorAccountError.MoradorNotFound)
+
+        return userRepository.createUser(
+            name = "", // Name comes from Pessoa, not needed for account creation
+            cpf = "",  // CPF comes from Pessoa, not needed for account creation
+            email = trimmedEmail,
+            role = UserRole.Morador(pessoaId = pessoaId, condominioId = condominioId),
+            password = trimmedPassword
+        )
+    }
+}

--- a/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/usecase/CreateUserUseCase.kt
+++ b/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/usecase/CreateUserUseCase.kt
@@ -36,6 +36,10 @@ class CreateUserUseCase(
             return Result.failure(CreateUserError.CondominioNotFound)
         }
 
+        if (role is UserRole.Morador && !condominioValidator.exists(role.condominioId)) {
+            return Result.failure(CreateUserError.CondominioNotFound)
+        }
+
         return userRepository.createUser(
             name = name.trim(),
             cpf = cpf.trim(),

--- a/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/usecase/GetMoradorAccountUseCase.kt
+++ b/features/login/domain/src/commonMain/kotlin/com/zalamena/login/domain/usecase/GetMoradorAccountUseCase.kt
@@ -1,0 +1,11 @@
+package com.zalamena.login.domain.usecase
+
+import com.zalamena.login.domain.models.User
+import com.zalamena.login.domain.repository.UserRepository
+
+class GetMoradorAccountUseCase(
+    private val userRepository: UserRepository
+) {
+    suspend operator fun invoke(pessoaId: String): Result<User?> =
+        userRepository.getUserByPessoaId(pessoaId)
+}

--- a/features/login/domain/src/jvmTest/kotlin/com/zalamena/login/domain/usecase/CreateMoradorAccountUseCaseTest.kt
+++ b/features/login/domain/src/jvmTest/kotlin/com/zalamena/login/domain/usecase/CreateMoradorAccountUseCaseTest.kt
@@ -1,0 +1,146 @@
+package com.zalamena.login.domain.usecase
+
+import com.zalamena.login.domain.models.User
+import com.zalamena.login.domain.models.UserRole
+import com.zalamena.login.domain.repository.MoradorValidator
+import com.zalamena.login.domain.repository.UserRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class CreateMoradorAccountUseCaseTest {
+
+    private val users = mutableListOf<User>()
+
+    private val fakeUserRepository = object : UserRepository {
+        override suspend fun createUser(
+            name: String,
+            cpf: String,
+            email: String,
+            role: UserRole,
+            password: String
+        ): Result<User> {
+            val user = User(id = "new-id", name = name, cpf = cpf, email = email, role = role)
+            users.add(user)
+            return Result.success(user)
+        }
+
+        override suspend fun getUsers(): Result<List<User>> = Result.success(users.toList())
+        override suspend fun getUsersByCondominioId(condominioId: String): Result<List<User>> =
+            Result.success(users.filter { (it.role as? UserRole.Porteiro)?.condominioId == condominioId })
+        override suspend fun deleteUser(userId: String): Result<Unit> = Result.success(Unit)
+        override suspend fun updateUserRole(userId: String, newRole: UserRole): Result<Unit> = Result.success(Unit)
+        override suspend fun authenticate(email: String, password: String): Result<User> =
+            Result.failure(NoSuchElementException())
+        override suspend fun getUserByPessoaId(pessoaId: String): Result<User?> =
+            Result.success(users.find { (it.role as? UserRole.Morador)?.pessoaId == pessoaId })
+    }
+
+    private val validMoradorValidator = MoradorValidator { "condo-1" }
+
+    private val invalidMoradorValidator = MoradorValidator { null }
+
+    private fun createUseCase(
+        moradorValidator: MoradorValidator = validMoradorValidator
+    ) = CreateMoradorAccountUseCase(fakeUserRepository, moradorValidator)
+
+    @Test
+    fun `returns EmptyEmail when email is blank`() = runTest {
+        val result = createUseCase()("pessoa-1", "", "password123")
+        assertTrue(result.isFailure)
+        assertIs<CreateMoradorAccountError.EmptyEmail>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `returns InvalidEmail when email has no at sign`() = runTest {
+        val result = createUseCase()("pessoa-1", "bademail", "password123")
+        assertTrue(result.isFailure)
+        assertIs<CreateMoradorAccountError.InvalidEmail>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `returns EmptyPassword when password is blank`() = runTest {
+        val result = createUseCase()("pessoa-1", "morador@test.com", "  ")
+        assertTrue(result.isFailure)
+        assertIs<CreateMoradorAccountError.EmptyPassword>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `returns MoradorNotFound when pessoa is not a morador`() = runTest {
+        val result = createUseCase(invalidMoradorValidator)("pessoa-1", "morador@test.com", "password123")
+        assertTrue(result.isFailure)
+        assertIs<CreateMoradorAccountError.MoradorNotFound>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `returns EmailAlreadyTaken when email is in use`() = runTest {
+        users.add(
+            User(
+                id = "existing",
+                name = "Existing",
+                cpf = "00000000000",
+                email = "taken@test.com",
+                role = UserRole.Admin
+            )
+        )
+
+        val result = createUseCase()("pessoa-1", "taken@test.com", "password123")
+        assertTrue(result.isFailure)
+        assertIs<CreateMoradorAccountError.EmailAlreadyTaken>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `returns AccountAlreadyExists when morador already has account`() = runTest {
+        users.add(
+            User(
+                id = "existing",
+                name = "",
+                cpf = "",
+                email = "existing@test.com",
+                role = UserRole.Morador(pessoaId = "pessoa-1", condominioId = "condo-1")
+            )
+        )
+
+        val result = createUseCase()("pessoa-1", "new@test.com", "password123")
+        assertTrue(result.isFailure)
+        assertIs<CreateMoradorAccountError.AccountAlreadyExists>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `creates user with Morador role on success`() = runTest {
+        val result = createUseCase()("pessoa-1", "morador@test.com", "password123")
+        assertTrue(result.isSuccess)
+
+        val user = result.getOrThrow()
+        assertIs<UserRole.Morador>(user.role)
+        assertEquals("pessoa-1", (user.role as UserRole.Morador).pessoaId)
+        assertEquals("condo-1", (user.role as UserRole.Morador).condominioId)
+        assertEquals("morador@test.com", user.email)
+    }
+
+    @Test
+    fun `trims email before creating user`() = runTest {
+        val result = createUseCase()("pessoa-1", "  morador@test.com  ", "password123")
+        assertTrue(result.isSuccess)
+        assertEquals("morador@test.com", result.getOrThrow().email)
+    }
+
+    @Test
+    fun `email uniqueness check is case insensitive`() = runTest {
+        users.add(
+            User(
+                id = "existing",
+                name = "Existing",
+                cpf = "00000000000",
+                email = "Taken@Test.com",
+                role = UserRole.Admin
+            )
+        )
+
+        val result = createUseCase()("pessoa-1", "taken@test.com", "password123")
+        assertTrue(result.isFailure)
+        assertIs<CreateMoradorAccountError.EmailAlreadyTaken>(result.exceptionOrNull())
+    }
+}

--- a/features/login/ui/src/commonMain/kotlin/com/zalamena/login/ui/LoginViewModel.kt
+++ b/features/login/ui/src/commonMain/kotlin/com/zalamena/login/ui/LoginViewModel.kt
@@ -56,6 +56,7 @@ class LoginViewModel(
                     val navEvent = when (val role = user.role) {
                         is UserRole.Admin -> LoginNavigationEvent.NavigateToAdminHome
                         is UserRole.Porteiro -> LoginNavigationEvent.NavigateToDoormanHome(role.condominioId)
+                        is UserRole.Morador -> LoginNavigationEvent.NavigateToDoormanHome(role.condominioId)
                     }
                     _uiState.update {
                         it.copy(isLoading = false, navigationEvent = navEvent)

--- a/features/login/ui/src/commonMain/kotlin/com/zalamena/login/ui/SplashViewModel.kt
+++ b/features/login/ui/src/commonMain/kotlin/com/zalamena/login/ui/SplashViewModel.kt
@@ -27,6 +27,7 @@ class SplashViewModel(
                 val role = loginRepository.getRole()
                 _navEvent.value = when (role) {
                     is UserRole.Porteiro -> SplashNavigationEvent.NavigateToDoormanHome(role.condominioId)
+                    is UserRole.Morador -> SplashNavigationEvent.NavigateToDoormanHome(role.condominioId)
                     is UserRole.Admin -> SplashNavigationEvent.NavigateToAdminHome
                     null -> SplashNavigationEvent.NavigateToLogin
                 }

--- a/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
+++ b/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
@@ -158,6 +158,13 @@ fun AppNavHost(
                             popUpTo(LoginRoute) { inclusive = true }
                         }
                     }
+                    is UserRole.Morador -> {
+                        condominioDashboardViewModel.setCondominioId(role.condominioId)
+                        condominioDashboardViewModel.setAdminMode(false)
+                        navController.navigate(DoormanHomeRoute) {
+                            popUpTo(LoginRoute) { inclusive = true }
+                        }
+                    }
                 }
             }
         )


### PR DESCRIPTION
## Summary
- Add `UserRole.Morador(pessoaId, condominioId)` to the auth system
- Admin can create login accounts for moradores from the morador detail screen
- Morador login routes to doorman home for their condomínio
- Cross-module DDD boundaries via functional interfaces (`MoradorValidator`, `MoradorAccountProvider`, `MoradorAccountCreator`)

## Test plan
- [x] 9 unit tests for `CreateMoradorAccountUseCase` (email uniqueness, validation, happy path)
- [ ] Open a morador's details in admin mode → "Criar conta de acesso" button visible
- [ ] Create an account → success message, button replaced with existing account email
- [ ] Try creating with a duplicate email → validation error
- [ ] Morador with existing account → button not shown, email displayed
- [ ] Log in with morador credentials → routed to doorman home screen

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)