### PR TITLE
Add morador home screen with role-based routing (#30)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/zalamena/condominios/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/zalamena/condominios/App.kt
@@ -9,7 +9,9 @@ import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDas
 import com.zalamena.condominios.navigation.ui.AdminHomeRoute
 import com.zalamena.condominios.navigation.ui.AppNavHost
 import com.zalamena.condominios.navigation.ui.DoormanHomeRoute
+import com.zalamena.condominios.navigation.ui.MoradorHomeRoute
 import com.zalamena.condominios.navigation.ui.SplashRoute
+import com.zalamena.condominios.navigation.ui.shell.MoradorShellViewModel
 import com.zalamena.condominios.theme.CondominiosTheme
 import com.zalamena.login.domain.usecase.LogoutUseCase
 import com.zalamena.login.ui.SplashNavigationEvent
@@ -27,6 +29,7 @@ fun App() {
         val splashViewModel: SplashViewModel = koinViewModel()
         val navEvent by splashViewModel.navEvent.collectAsState()
         val condominioDashboardViewModel: CondominioDashboardViewModel = koinViewModel()
+        val moradorShellViewModel: MoradorShellViewModel = koinViewModel()
         val logoutUseCase: LogoutUseCase = koinInject()
 
         LaunchedEffect(navEvent) {
@@ -51,6 +54,13 @@ fun App() {
                     }
                     splashViewModel.onNavigationHandled()
                 }
+                is SplashNavigationEvent.NavigateToMoradorHome -> {
+                    moradorShellViewModel.setCondominioId(event.condominioId)
+                    navController.navigate(MoradorHomeRoute) {
+                        popUpTo(SplashRoute) { inclusive = true }
+                    }
+                    splashViewModel.onNavigationHandled()
+                }
                 null -> {}
             }
         }
@@ -71,6 +81,7 @@ fun App() {
             koinViewModel(),
             koinViewModel(),
             koinViewModel(),
+            moradorShellViewModel,
             onLogout = { logoutUseCase() }
         )
     }

--- a/features/di/build.gradle.kts
+++ b/features/di/build.gradle.kts
@@ -75,6 +75,8 @@ kotlin {
             api(project(":features:login:data"))
             api(project(":features:login:domain"))
             api(project(":features:login:ui"))
+
+            api(project(":features:navigation:ui"))
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
+++ b/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
@@ -41,6 +41,7 @@ import com.zalamena.condominios.condominio.ui.moradores.details.MoradorInfoViewM
 import com.zalamena.condominios.condominio.ui.addmorador.searchpessoa.SearchPessoaViewModel
 import com.zalamena.condominios.condominio.ui.moradores.search.MoradorSearchViewModel
 import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListViewModel
+import com.zalamena.condominios.navigation.ui.shell.MoradorShellViewModel
 import com.zalamena.condominios.condominio.domain.porteiro.models.PorteiroInfo
 import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroDeleter
 import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroProvider
@@ -235,4 +236,5 @@ val viewModelModule = module {
     viewModelOf(::MoradorSearchViewModel)
     viewModelOf(::MoradorInfoViewModel)
     viewModelOf(::SearchPessoaViewModel)
+    viewModelOf(::MoradorShellViewModel)
 }

--- a/features/login/ui/src/commonMain/kotlin/com/zalamena/login/ui/LoginScreen.kt
+++ b/features/login/ui/src/commonMain/kotlin/com/zalamena/login/ui/LoginScreen.kt
@@ -50,6 +50,13 @@ fun LoginScreen(
                 onLoginSuccess(UserRole.Porteiro((state.navigationEvent as LoginNavigationEvent.NavigateToDoormanHome).condominioId))
                 viewModel.onNavigationHandled()
             }
+            is LoginNavigationEvent.NavigateToMoradorHome -> {
+                onLoginSuccess(UserRole.Morador(
+                    pessoaId = "",
+                    condominioId = (state.navigationEvent as LoginNavigationEvent.NavigateToMoradorHome).condominioId
+                ))
+                viewModel.onNavigationHandled()
+            }
             null -> {}
         }
     }

--- a/features/login/ui/src/commonMain/kotlin/com/zalamena/login/ui/LoginViewModel.kt
+++ b/features/login/ui/src/commonMain/kotlin/com/zalamena/login/ui/LoginViewModel.kt
@@ -22,6 +22,7 @@ data class LoginUiState(
 sealed class LoginNavigationEvent {
     object NavigateToAdminHome : LoginNavigationEvent()
     data class NavigateToDoormanHome(val condominioId: String) : LoginNavigationEvent()
+    data class NavigateToMoradorHome(val condominioId: String) : LoginNavigationEvent()
 }
 
 class LoginViewModel(
@@ -56,7 +57,7 @@ class LoginViewModel(
                     val navEvent = when (val role = user.role) {
                         is UserRole.Admin -> LoginNavigationEvent.NavigateToAdminHome
                         is UserRole.Porteiro -> LoginNavigationEvent.NavigateToDoormanHome(role.condominioId)
-                        is UserRole.Morador -> LoginNavigationEvent.NavigateToDoormanHome(role.condominioId)
+                        is UserRole.Morador -> LoginNavigationEvent.NavigateToMoradorHome(role.condominioId)
                     }
                     _uiState.update {
                         it.copy(isLoading = false, navigationEvent = navEvent)

--- a/features/login/ui/src/commonMain/kotlin/com/zalamena/login/ui/SplashViewModel.kt
+++ b/features/login/ui/src/commonMain/kotlin/com/zalamena/login/ui/SplashViewModel.kt
@@ -12,6 +12,7 @@ sealed class SplashNavigationEvent {
     object NavigateToLogin : SplashNavigationEvent()
     object NavigateToAdminHome : SplashNavigationEvent()
     data class NavigateToDoormanHome(val condominioId: String) : SplashNavigationEvent()
+    data class NavigateToMoradorHome(val condominioId: String) : SplashNavigationEvent()
 }
 
 class SplashViewModel(
@@ -27,7 +28,7 @@ class SplashViewModel(
                 val role = loginRepository.getRole()
                 _navEvent.value = when (role) {
                     is UserRole.Porteiro -> SplashNavigationEvent.NavigateToDoormanHome(role.condominioId)
-                    is UserRole.Morador -> SplashNavigationEvent.NavigateToDoormanHome(role.condominioId)
+                    is UserRole.Morador -> SplashNavigationEvent.NavigateToMoradorHome(role.condominioId)
                     is UserRole.Admin -> SplashNavigationEvent.NavigateToAdminHome
                     null -> SplashNavigationEvent.NavigateToLogin
                 }

--- a/features/navigation/ui/build.gradle.kts
+++ b/features/navigation/ui/build.gradle.kts
@@ -73,6 +73,7 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.assertk)
+            implementation(libs.kotlinx.coroutines.test)
         }
         jvmMain.dependencies {
             implementation(compose.desktop.currentOs)

--- a/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
+++ b/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
@@ -37,6 +37,8 @@ import com.zalamena.condominios.condominio.ui.moradores.search.MoradorSearchView
 import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListViewModel
 import com.zalamena.condominios.navigation.ui.shell.AdminShellScreen
 import com.zalamena.condominios.navigation.ui.shell.DoormanShellScreen
+import com.zalamena.condominios.navigation.ui.shell.MoradorShellScreen
+import com.zalamena.condominios.navigation.ui.shell.MoradorShellViewModel
 import com.zalamena.login.ui.LoginViewModel
 import com.zalamena.login.ui.createuser.CreateUserViewModel
 import com.zalamena.login.ui.createuser.navigation.createUserNavHost
@@ -54,6 +56,9 @@ object AdminHomeRoute
 
 @Serializable
 object DoormanHomeRoute
+
+@Serializable
+object MoradorHomeRoute
 
 
 @Composable
@@ -73,6 +78,7 @@ fun AppNavHost(
     moradorSearchViewModel: MoradorSearchViewModel,
     moradorInfoViewModel: MoradorInfoViewModel,
     searchPessoaViewModel: SearchPessoaViewModel,
+    moradorShellViewModel: MoradorShellViewModel,
     onLogout: suspend () -> Unit = {}
 ) {
     NavHost(navController, startDestination = SplashRoute) {
@@ -141,6 +147,14 @@ fun AppNavHost(
             )
         }
 
+        composable<MoradorHomeRoute> {
+            MoradorShellScreen(
+                parentNavController = navController,
+                moradorShellViewModel = moradorShellViewModel,
+                onLogout = onLogout
+            )
+        }
+
         loginNavHost(
             navController,
             loginViewModel = loginViewModel,
@@ -159,9 +173,8 @@ fun AppNavHost(
                         }
                     }
                     is UserRole.Morador -> {
-                        condominioDashboardViewModel.setCondominioId(role.condominioId)
-                        condominioDashboardViewModel.setAdminMode(false)
-                        navController.navigate(DoormanHomeRoute) {
+                        moradorShellViewModel.setCondominioId(role.condominioId)
+                        navController.navigate(MoradorHomeRoute) {
                             popUpTo(LoginRoute) { inclusive = true }
                         }
                     }

--- a/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/shell/MoradorShellScreen.kt
+++ b/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/shell/MoradorShellScreen.kt
@@ -1,0 +1,263 @@
+package com.zalamena.condominios.navigation.ui.shell
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ExitToApp
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.LocationCity
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.navigation.NavController
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.zalamena.login.ui.navigation.LoginRoute
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+
+@Serializable
+object MoradorHomeTab
+
+@Serializable
+object MoradorReservasTab
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MoradorShellScreen(
+    parentNavController: NavController,
+    moradorShellViewModel: MoradorShellViewModel,
+    onLogout: suspend () -> Unit
+) {
+    val tabNavController = rememberNavController()
+    val navBackStackEntry by tabNavController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+    val coroutineScope = rememberCoroutineScope()
+    val uiState by moradorShellViewModel.uiState.collectAsState()
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                moradorShellViewModel.loadCondominio()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        text = uiState.condominioName.ifEmpty { "Carregando..." },
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                },
+                actions = {
+                    IconButton(
+                        onClick = {
+                            coroutineScope.launch {
+                                onLogout()
+                                parentNavController.navigate(LoginRoute) {
+                                    popUpTo(0) { inclusive = true }
+                                }
+                            }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ExitToApp,
+                            contentDescription = "Sair"
+                        )
+                    }
+                }
+            )
+        },
+        bottomBar = {
+            NavigationBar {
+                NavigationBarItem(
+                    icon = { Icon(Icons.Default.Home, contentDescription = "Inicio") },
+                    label = { Text("Inicio") },
+                    selected = currentRoute?.contains("MoradorHomeTab") == true,
+                    onClick = {
+                        tabNavController.navigate(MoradorHomeTab) {
+                            popUpTo(tabNavController.graph.findStartDestination().id) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    }
+                )
+                NavigationBarItem(
+                    icon = { Icon(Icons.Default.CalendarMonth, contentDescription = "Reservas") },
+                    label = { Text("Reservas") },
+                    selected = currentRoute?.contains("MoradorReservasTab") == true,
+                    onClick = {
+                        tabNavController.navigate(MoradorReservasTab) {
+                            popUpTo(tabNavController.graph.findStartDestination().id) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    }
+                )
+            }
+        }
+    ) { innerPadding ->
+        NavHost(
+            navController = tabNavController,
+            startDestination = MoradorHomeTab,
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            composable<MoradorHomeTab> {
+                MoradorHomeContent(condominioName = uiState.condominioName)
+            }
+
+            composable<MoradorReservasTab> {
+                MoradorReservasPlaceholder()
+            }
+        }
+    }
+}
+
+@Composable
+fun MoradorHomeContent(condominioName: String) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        if (condominioName.isNotEmpty()) {
+            Text(
+                text = condominioName,
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        Text(
+            text = "Comodidades",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        EmptyStateCard(
+            icon = Icons.Default.LocationCity,
+            message = "Nenhuma comodidade disponivel"
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "Minhas Reservas",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        EmptyStateCard(
+            icon = Icons.Default.CalendarMonth,
+            message = "Nenhuma reserva"
+        )
+    }
+}
+
+@Composable
+fun MoradorReservasPlaceholder() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.CalendarMonth,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Em breve",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "O sistema de reservas esta sendo desenvolvido",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmptyStateCard(
+    icon: ImageVector,
+    message: String
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(40.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}

--- a/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/shell/MoradorShellViewModel.kt
+++ b/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/shell/MoradorShellViewModel.kt
@@ -1,0 +1,54 @@
+package com.zalamena.condominios.navigation.ui.shell
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zalamena.condominios.condominio.domain.condominio.usecase.GetCondominioUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class MoradorShellUiState(
+    val condominioName: String = "",
+    val isLoading: Boolean = false,
+    val error: String? = null
+)
+
+class MoradorShellViewModel(
+    private val getCondominioUseCase: GetCondominioUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(MoradorShellUiState())
+    val uiState: StateFlow<MoradorShellUiState> = _uiState
+
+    private var condominioId: String = ""
+
+    fun setCondominioId(id: String) {
+        condominioId = id
+    }
+
+    fun loadCondominio() {
+        if (condominioId.isEmpty()) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            getCondominioUseCase(condominioId)
+                .onSuccess { condominio ->
+                    _uiState.update {
+                        it.copy(
+                            condominioName = condominio.nome,
+                            isLoading = false
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = e.message ?: "Erro ao carregar condominio"
+                        )
+                    }
+                }
+        }
+    }
+}

--- a/features/navigation/ui/src/commonTest/kotlin/com/zalamena/condominios/navigation/ui/shell/MoradorShellViewModelTest.kt
+++ b/features/navigation/ui/src/commonTest/kotlin/com/zalamena/condominios/navigation/ui/shell/MoradorShellViewModelTest.kt
@@ -1,0 +1,95 @@
+package com.zalamena.condominios.navigation.ui.shell
+
+import com.zalamena.condominios.condominio.domain.condominio.models.Condominio
+import com.zalamena.condominios.condominio.domain.condominio.usecase.GetCondominioUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.kodein.mock.Mock
+import com.zalamena.condominios.condominio.domain.condominio.repository.CondominioRepository
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MoradorShellViewModelTest : TestsWithMocks() {
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+
+    @Mock
+    lateinit var condominioRepository: CondominioRepository
+
+    private val getCondominioUseCase by lazy { GetCondominioUseCase(condominioRepository) }
+    private val viewModel by lazy { MoradorShellViewModel(getCondominioUseCase) }
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `GIVEN initial state THEN condominioName is empty and isLoading is false`() {
+        val state = viewModel.uiState.value
+        assertEquals("", state.condominioName)
+        assertTrue(!state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `GIVEN condominioId set WHEN loadCondominio THEN condominioName is updated`() = runTest {
+        val condominio = Condominio.dummy.copy(id = "condo-1", nome = "Residencial Sol")
+        everySuspending { condominioRepository.getCondominio("condo-1") } returns Result.success(condominio)
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadCondominio()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals("Residencial Sol", state.condominioName)
+        assertTrue(!state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `GIVEN condominioId set WHEN loadCondominio fails THEN error is set`() = runTest {
+        everySuspending { condominioRepository.getCondominio("condo-1") } returns Result.failure(Exception("Not found"))
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadCondominio()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals("", state.condominioName)
+        assertTrue(!state.isLoading)
+        assertEquals("Not found", state.error)
+    }
+
+    @Test
+    fun `GIVEN no condominioId set WHEN loadCondominio THEN nothing happens`() = runTest {
+        viewModel.loadCondominio()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals("", state.condominioName)
+        assertTrue(!state.isLoading)
+        assertNull(state.error)
+    }
+}


### PR DESCRIPTION
## Summary
- New `MoradorShellScreen` with bottom navigation (Inicio and Reservas tabs), condominio name in top bar, and logout button
- New `MoradorShellViewModel` that loads the assigned condominio name, with 4 unit tests
- Morador login and splash now route to dedicated `MoradorHomeRoute` instead of reusing the doorman view
- Added `NavigateToMoradorHome` event to both `LoginViewModel` and `SplashViewModel`
- Wired `MoradorShellViewModel` in DI module (added `navigation:ui` dependency to `di` module)

Closes #30

## Test plan
- [ ] Log in as a morador user and verify the morador home screen appears (not doorman view)
- [ ] Verify bottom nav has Inicio and Reservas tabs
- [ ] Verify condominio name shows in top bar after loading
- [ ] Verify logout button works and returns to login screen
- [ ] Run `runCommonTests` — all tests pass including 4 new MoradorShellViewModel tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)