### PR TITLE
Add amenity CRUD and morador amenity display (#31)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/zalamena/condominios/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/zalamena/condominios/App.kt
@@ -82,6 +82,8 @@ fun App() {
             koinViewModel(),
             koinViewModel(),
             moradorShellViewModel,
+            koinViewModel(),
+            koinViewModel(),
             onLogout = { logoutUseCase() }
         )
     }

--- a/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/amenity/dao/AmenityDao.kt
+++ b/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/amenity/dao/AmenityDao.kt
@@ -1,0 +1,15 @@
+package com.zalamena.condominios.condominio.data.amenity.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.zalamena.condominios.condominio.data.amenity.entity.AmenityEntity
+
+@Dao
+interface AmenityDao {
+    @Insert
+    suspend fun insertAmenity(amenity: AmenityEntity)
+
+    @Query("SELECT * FROM Amenity WHERE condominioId = :condominioId")
+    suspend fun getAmenitiesByCondominio(condominioId: String): List<AmenityEntity>
+}

--- a/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/amenity/entity/AmenityEntity.kt
+++ b/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/amenity/entity/AmenityEntity.kt
@@ -1,0 +1,16 @@
+package com.zalamena.condominios.condominio.data.amenity.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "Amenity")
+data class AmenityEntity(
+    @PrimaryKey
+    val id: String,
+    val condominioId: String,
+    val nome: String,
+    val descricao: String,
+    val capacidade: Int?,
+    val precoUso: Double?,
+    val requerAprovacaoSindico: Boolean
+)

--- a/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/amenity/mapper/AmenityMapper.kt
+++ b/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/amenity/mapper/AmenityMapper.kt
@@ -1,0 +1,24 @@
+package com.zalamena.condominios.condominio.data.amenity.mapper
+
+import com.zalamena.condominios.condominio.data.amenity.entity.AmenityEntity
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+
+fun AmenityEntity.toDomain(): Amenity = Amenity(
+    id = id,
+    condominioId = condominioId,
+    nome = nome,
+    descricao = descricao,
+    capacidade = capacidade,
+    precoUso = precoUso,
+    requerAprovacaoSindico = requerAprovacaoSindico
+)
+
+fun Amenity.toEntity(): AmenityEntity = AmenityEntity(
+    id = id,
+    condominioId = condominioId,
+    nome = nome,
+    descricao = descricao,
+    capacidade = capacidade,
+    precoUso = precoUso,
+    requerAprovacaoSindico = requerAprovacaoSindico
+)

--- a/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/amenity/repository/AmenityRepositoryImpl.kt
+++ b/features/condominio/data/src/commonMain/kotlin/com/zalamena/condominios/condominio/data/amenity/repository/AmenityRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package com.zalamena.condominios.condominio.data.amenity.repository
+
+import com.zalamena.condominios.condominio.data.amenity.dao.AmenityDao
+import com.zalamena.condominios.condominio.data.amenity.mapper.toDomain
+import com.zalamena.condominios.condominio.data.amenity.mapper.toEntity
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+import com.zalamena.condominios.condominio.domain.amenity.repository.AmenityRepository
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+class AmenityRepositoryImpl(
+    private val amenityDao: AmenityDao
+) : AmenityRepository {
+
+    @OptIn(ExperimentalUuidApi::class)
+    override suspend fun addAmenity(amenity: Amenity): Result<Unit> {
+        return runCatching {
+            val id = Uuid.random().toString()
+            amenityDao.insertAmenity(amenity.copy(id = id).toEntity())
+        }
+    }
+
+    override suspend fun getAmenitiesByCondominio(condominioId: String): Result<List<Amenity>> {
+        return runCatching {
+            amenityDao.getAmenitiesByCondominio(condominioId).map { it.toDomain() }
+        }
+    }
+}

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/amenity/model/Amenity.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/amenity/model/Amenity.kt
@@ -1,0 +1,23 @@
+package com.zalamena.condominios.condominio.domain.amenity.model
+
+data class Amenity(
+    val id: String,
+    val condominioId: String,
+    val nome: String,
+    val descricao: String = "",
+    val capacidade: Int? = null,
+    val precoUso: Double? = null,
+    val requerAprovacaoSindico: Boolean = false
+) {
+    companion object {
+        val dummy = Amenity(
+            id = "amenity-1",
+            condominioId = "condo-1",
+            nome = "Salao de Festas",
+            descricao = "Salao para eventos",
+            capacidade = 50,
+            precoUso = 200.0,
+            requerAprovacaoSindico = false
+        )
+    }
+}

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/amenity/repository/AmenityRepository.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/amenity/repository/AmenityRepository.kt
@@ -1,0 +1,8 @@
+package com.zalamena.condominios.condominio.domain.amenity.repository
+
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+
+interface AmenityRepository {
+    suspend fun addAmenity(amenity: Amenity): Result<Unit>
+    suspend fun getAmenitiesByCondominio(condominioId: String): Result<List<Amenity>>
+}

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/amenity/usecase/AddAmenityUseCase.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/amenity/usecase/AddAmenityUseCase.kt
@@ -1,0 +1,18 @@
+package com.zalamena.condominios.condominio.domain.amenity.usecase
+
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+import com.zalamena.condominios.condominio.domain.amenity.repository.AmenityRepository
+
+class AddAmenityUseCase(
+    private val amenityRepository: AmenityRepository
+) {
+    suspend operator fun invoke(amenity: Amenity): Result<Unit> {
+        if (amenity.nome.isBlank()) {
+            return Result.failure(IllegalArgumentException("Nome e obrigatorio"))
+        }
+        if (amenity.condominioId.isBlank()) {
+            return Result.failure(IllegalArgumentException("condominioId e obrigatorio"))
+        }
+        return amenityRepository.addAmenity(amenity)
+    }
+}

--- a/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/amenity/usecase/GetAmenitiesByCondominioUseCase.kt
+++ b/features/condominio/domain/src/commonMain/kotlin/com/zalamena/condominios/condominio/domain/amenity/usecase/GetAmenitiesByCondominioUseCase.kt
@@ -1,0 +1,12 @@
+package com.zalamena.condominios.condominio.domain.amenity.usecase
+
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+import com.zalamena.condominios.condominio.domain.amenity.repository.AmenityRepository
+
+class GetAmenitiesByCondominioUseCase(
+    private val amenityRepository: AmenityRepository
+) {
+    suspend operator fun invoke(condominioId: String): Result<List<Amenity>> {
+        return amenityRepository.getAmenitiesByCondominio(condominioId)
+    }
+}

--- a/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/amenity/AddAmenityUseCaseTest.kt
+++ b/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/amenity/AddAmenityUseCaseTest.kt
@@ -1,0 +1,73 @@
+package com.zalamena.condominios.condominio.domain.amenity
+
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+import com.zalamena.condominios.condominio.domain.amenity.repository.AmenityRepository
+import com.zalamena.condominios.condominio.domain.amenity.usecase.AddAmenityUseCase
+import kotlinx.coroutines.test.runTest
+import org.kodein.mock.Mock
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class AddAmenityUseCaseTest : TestsWithMocks() {
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+
+    @Mock
+    lateinit var amenityRepository: AmenityRepository
+
+    private val useCase by lazy { AddAmenityUseCase(amenityRepository) }
+
+    @Test
+    fun `GIVEN valid amenity WHEN invoke THEN returns success`() = runTest {
+        val amenity = Amenity.dummy
+        everySuspending { amenityRepository.addAmenity(amenity) } returns Result.success(Unit)
+
+        val result = useCase(amenity)
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `GIVEN blank nome WHEN invoke THEN returns failure`() = runTest {
+        val amenity = Amenity.dummy.copy(nome = "")
+
+        val result = useCase(amenity)
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+    }
+
+    @Test
+    fun `GIVEN whitespace nome WHEN invoke THEN returns failure`() = runTest {
+        val amenity = Amenity.dummy.copy(nome = "   ")
+
+        val result = useCase(amenity)
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+    }
+
+    @Test
+    fun `GIVEN blank condominioId WHEN invoke THEN returns failure`() = runTest {
+        val amenity = Amenity.dummy.copy(condominioId = "")
+
+        val result = useCase(amenity)
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+    }
+
+    @Test
+    fun `GIVEN repository fails WHEN invoke THEN returns failure`() = runTest {
+        val amenity = Amenity.dummy
+        everySuspending { amenityRepository.addAmenity(amenity) } returns Result.failure(Exception("DB error"))
+
+        val result = useCase(amenity)
+
+        assertTrue(result.isFailure)
+    }
+}

--- a/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/amenity/GetAmenitiesByCondominioUseCaseTest.kt
+++ b/features/condominio/domain/src/commonTest/kotlin/com/zalamena/condominios/condominio/domain/amenity/GetAmenitiesByCondominioUseCaseTest.kt
@@ -1,0 +1,54 @@
+package com.zalamena.condominios.condominio.domain.amenity
+
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+import com.zalamena.condominios.condominio.domain.amenity.repository.AmenityRepository
+import com.zalamena.condominios.condominio.domain.amenity.usecase.GetAmenitiesByCondominioUseCase
+import kotlinx.coroutines.test.runTest
+import org.kodein.mock.Mock
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GetAmenitiesByCondominioUseCaseTest : TestsWithMocks() {
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+
+    @Mock
+    lateinit var amenityRepository: AmenityRepository
+
+    private val useCase by lazy { GetAmenitiesByCondominioUseCase(amenityRepository) }
+
+    @Test
+    fun `GIVEN amenities exist WHEN invoke THEN returns list`() = runTest {
+        val amenities = listOf(Amenity.dummy, Amenity.dummy.copy(id = "amenity-2", nome = "Churrasqueira"))
+        everySuspending { amenityRepository.getAmenitiesByCondominio("condo-1") } returns Result.success(amenities)
+
+        val result = useCase("condo-1")
+
+        assertTrue(result.isSuccess)
+        assertEquals(2, result.getOrThrow().size)
+    }
+
+    @Test
+    fun `GIVEN no amenities WHEN invoke THEN returns empty list`() = runTest {
+        everySuspending { amenityRepository.getAmenitiesByCondominio("condo-1") } returns Result.success(emptyList())
+
+        val result = useCase("condo-1")
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    @Test
+    fun `GIVEN repository fails WHEN invoke THEN returns failure`() = runTest {
+        everySuspending { amenityRepository.getAmenitiesByCondominio("condo-1") } returns Result.failure(Exception("error"))
+
+        val result = useCase("condo-1")
+
+        assertTrue(result.isFailure)
+    }
+}

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/amenity/add/AddAmenityScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/amenity/add/AddAmenityScreen.kt
@@ -1,0 +1,193 @@
+package com.zalamena.condominios.condominio.ui.amenity.add
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddAmenityScreen(
+    viewModel: AddAmenityViewModel,
+    onSuccess: () -> Unit = {},
+    onBack: () -> Unit = {}
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(uiState.navigationEvent) {
+        when (uiState.navigationEvent) {
+            is AddAmenityNavigationEvent.Success -> {
+                onSuccess()
+                viewModel.onNavigationHandled()
+            }
+            null -> Unit
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Adicionar Comodidade") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Voltar"
+                        )
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = uiState.nome,
+                onValueChange = { viewModel.setNome(it) },
+                label = { Text("Nome *") },
+                isError = uiState.nomeError != null,
+                supportingText = uiState.nomeError?.let { error -> { Text(error) } },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = uiState.descricao,
+                onValueChange = { viewModel.setDescricao(it) },
+                label = { Text("Descricao") },
+                modifier = Modifier.fillMaxWidth(),
+                minLines = 2,
+                maxLines = 4
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = uiState.capacidade,
+                onValueChange = { viewModel.setCapacidade(it) },
+                label = { Text("Capacidade") },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                singleLine = true
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = uiState.precoUso,
+                onValueChange = { viewModel.setPrecoUso(it) },
+                label = { Text("Preco por uso") },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                visualTransformation = BrlCurrencyVisualTransformation(),
+                singleLine = true
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Requer aprovacao do sindico",
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Switch(
+                    checked = uiState.requerAprovacaoSindico,
+                    onCheckedChange = { viewModel.setRequerAprovacaoSindico(it) }
+                )
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            uiState.errorMessage?.let { error ->
+                Text(
+                    text = error,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall
+                )
+                Spacer(Modifier.height(8.dp))
+            }
+
+            Button(
+                onClick = { viewModel.submit() },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !uiState.isLoading
+            ) {
+                if (uiState.isLoading) {
+                    CircularProgressIndicator()
+                } else {
+                    Text("Salvar")
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}
+
+internal class BrlCurrencyVisualTransformation : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val digits = text.text
+        val cents = digits.padStart(3, '0').toLongOrNull() ?: 0L
+        val integerPart = cents / 100
+        val decimalPart = (cents % 100).toString().padStart(2, '0')
+
+        val integerFormatted = integerPart.toString()
+            .reversed()
+            .chunked(3)
+            .joinToString(".")
+            .reversed()
+
+        val formatted = "R$ $integerFormatted,$decimalPart"
+
+        val offsetMapping = object : OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int = formatted.length
+            override fun transformedToOriginal(offset: Int): Int = digits.length
+        }
+
+        return TransformedText(AnnotatedString(formatted), offsetMapping)
+    }
+}

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/amenity/add/AddAmenityViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/amenity/add/AddAmenityViewModel.kt
@@ -1,0 +1,114 @@
+package com.zalamena.condominios.condominio.ui.amenity.add
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+import com.zalamena.condominios.condominio.domain.amenity.usecase.AddAmenityUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class AddAmenityUiState(
+    val condominioId: String = "",
+    val nome: String = "",
+    val descricao: String = "",
+    val capacidade: String = "",
+    val precoUso: String = "",
+    val requerAprovacaoSindico: Boolean = false,
+    val nomeError: String? = null,
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+    val navigationEvent: AddAmenityNavigationEvent? = null
+)
+
+sealed class AddAmenityNavigationEvent {
+    object Success : AddAmenityNavigationEvent()
+}
+
+class AddAmenityViewModel(
+    private val addAmenityUseCase: AddAmenityUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AddAmenityUiState())
+    val uiState: StateFlow<AddAmenityUiState> = _uiState.asStateFlow()
+
+    fun reset() {
+        _uiState.update { AddAmenityUiState() }
+    }
+
+    fun setCondominioId(condominioId: String) {
+        _uiState.update { it.copy(condominioId = condominioId) }
+    }
+
+    fun setNome(nome: String) {
+        _uiState.update { it.copy(nome = nome, nomeError = null, errorMessage = null) }
+    }
+
+    fun setDescricao(descricao: String) {
+        _uiState.update { it.copy(descricao = descricao) }
+    }
+
+    fun setCapacidade(capacidade: String) {
+        val filtered = capacidade.filter { it.isDigit() }
+        _uiState.update { it.copy(capacidade = filtered) }
+    }
+
+    fun setPrecoUso(precoUso: String) {
+        val filtered = precoUso.filter { it.isDigit() }
+        _uiState.update { it.copy(precoUso = filtered) }
+    }
+
+    fun setRequerAprovacaoSindico(requer: Boolean) {
+        _uiState.update { it.copy(requerAprovacaoSindico = requer) }
+    }
+
+    fun submit() {
+        val state = _uiState.value
+
+        if (state.nome.isBlank()) {
+            _uiState.update { it.copy(nomeError = "Nome e obrigatorio") }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+
+            val amenity = Amenity(
+                id = "",
+                condominioId = state.condominioId,
+                nome = state.nome.trim(),
+                descricao = state.descricao.trim(),
+                capacidade = state.capacidade.toIntOrNull(),
+                precoUso = state.precoUso.toLongOrNull()?.let { it / 100.0 },
+                requerAprovacaoSindico = state.requerAprovacaoSindico
+            )
+
+            val result = addAmenityUseCase(amenity)
+
+            when {
+                result.isSuccess -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            navigationEvent = AddAmenityNavigationEvent.Success
+                        )
+                    }
+                }
+                result.isFailure -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = result.exceptionOrNull()?.message
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun onNavigationHandled() {
+        _uiState.update { it.copy(navigationEvent = null) }
+    }
+}

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/amenity/list/AmenityListScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/amenity/list/AmenityListScreen.kt
@@ -1,0 +1,186 @@
+package com.zalamena.condominios.condominio.ui.amenity.list
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.LocationCity
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.zalamena.condominios.common.ui.components.EmptyState
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AmenityListScreen(
+    viewModel: AmenityListViewModel,
+    onNavigateToAddAmenity: (condominioId: String) -> Unit = {},
+    onBack: () -> Unit = {}
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.loadAmenities()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    LaunchedEffect(uiState.navigationEvent) {
+        when (val event = uiState.navigationEvent) {
+            is AmenityListNavigationEvent.AddAmenity -> {
+                onNavigateToAddAmenity(event.condominioId)
+                viewModel.onNavigationHandled()
+            }
+            null -> Unit
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Comodidades") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Voltar"
+                        )
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { viewModel.onAddAmenityClick() },
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Adicionar comodidade")
+            }
+        }
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when {
+                uiState.isLoading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+                uiState.error != null -> {
+                    Text(
+                        text = "Erro ao carregar comodidades",
+                        modifier = Modifier.align(Alignment.Center),
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+                uiState.amenities.isEmpty() -> {
+                    EmptyState(
+                        message = "Nenhuma comodidade cadastrada",
+                        icon = Icons.Default.LocationCity,
+                        actionLabel = "Adicionar comodidade",
+                        onAction = { viewModel.onAddAmenityClick() }
+                    )
+                }
+                else -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        item { Spacer(Modifier.height(8.dp)) }
+                        items(uiState.amenities) { amenity ->
+                            AmenityCard(amenity)
+                        }
+                        item { Spacer(Modifier.height(80.dp)) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AmenityCard(amenity: Amenity) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(
+                text = amenity.nome,
+                style = MaterialTheme.typography.titleMedium
+            )
+            if (amenity.descricao.isNotBlank()) {
+                Text(
+                    text = amenity.descricao,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(Modifier.height(4.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                amenity.capacidade?.let { cap ->
+                    Text(
+                        text = "$cap pessoas",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                amenity.precoUso?.let { preco ->
+                    Text(
+                        text = formatBrl(preco),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+internal fun formatBrl(value: Double): String {
+    val cents = (value * 100).toLong()
+    val integerPart = cents / 100
+    val decimalPart = (cents % 100).toString().padStart(2, '0')
+    val integerFormatted = integerPart.toString()
+        .reversed()
+        .chunked(3)
+        .joinToString(".")
+        .reversed()
+    return "R$ $integerFormatted,$decimalPart"
+}

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/amenity/list/AmenityListViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/amenity/list/AmenityListViewModel.kt
@@ -1,0 +1,66 @@
+package com.zalamena.condominios.condominio.ui.amenity.list
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+import com.zalamena.condominios.condominio.domain.amenity.usecase.GetAmenitiesByCondominioUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class AmenityListUiState(
+    val condominioId: String = "",
+    val amenities: List<Amenity> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val navigationEvent: AmenityListNavigationEvent? = null
+)
+
+sealed class AmenityListNavigationEvent {
+    data class AddAmenity(val condominioId: String) : AmenityListNavigationEvent()
+}
+
+class AmenityListViewModel(
+    private val getAmenitiesByCondominioUseCase: GetAmenitiesByCondominioUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AmenityListUiState())
+    val uiState: StateFlow<AmenityListUiState> = _uiState.asStateFlow()
+
+    fun setCondominioId(condominioId: String) {
+        _uiState.update { it.copy(condominioId = condominioId) }
+    }
+
+    fun loadAmenities() {
+        val condominioId = _uiState.value.condominioId
+        if (condominioId.isBlank()) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+
+            getAmenitiesByCondominioUseCase(condominioId)
+                .onSuccess { amenities ->
+                    _uiState.update {
+                        it.copy(isLoading = false, amenities = amenities)
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.update {
+                        it.copy(isLoading = false, error = e.message)
+                    }
+                }
+        }
+    }
+
+    fun onAddAmenityClick() {
+        val condominioId = _uiState.value.condominioId
+        if (condominioId.isBlank()) return
+        _uiState.update { it.copy(navigationEvent = AmenityListNavigationEvent.AddAmenity(condominioId)) }
+    }
+
+    fun onNavigationHandled() {
+        _uiState.update { it.copy(navigationEvent = null) }
+    }
+}

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardScreen.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardScreen.kt
@@ -52,6 +52,7 @@ fun CondominioDashboardScreen(
     onNavigateToCreatePorteiro: (condominioId: String) -> Unit = {},
     onNavigateToPorteiroList: (condominioId: String) -> Unit = {},
     onNavigateToSearchMorador: (condominioId: String) -> Unit = {},
+    onNavigateToAmenityList: (condominioId: String) -> Unit = {},
     onLogout: () -> Unit = {},
     onBack: () -> Unit = {}
 ) {
@@ -88,6 +89,10 @@ fun CondominioDashboardScreen(
             }
             is DashboardNavigationEvent.SearchMorador -> {
                 onNavigateToSearchMorador(event.condominioId)
+                viewModel.onNavigationHandled()
+            }
+            is DashboardNavigationEvent.AmenityList -> {
+                onNavigateToAmenityList(event.condominioId)
                 viewModel.onNavigationHandled()
             }
             is DashboardNavigationEvent.Logout -> {
@@ -148,6 +153,13 @@ fun CondominioDashboardScreen(
                                 onClick = {
                                     menuExpanded = false
                                     viewModel.onCreatePorteiroClick()
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Comodidades") },
+                                onClick = {
+                                    menuExpanded = false
+                                    viewModel.onAmenityListClick()
                                 }
                             )
                         }

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardViewModel.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/CondominioDashboardViewModel.kt
@@ -28,6 +28,7 @@ sealed class DashboardNavigationEvent {
     data class CreatePorteiro(val condominioId: String) : DashboardNavigationEvent()
     data class PorteiroList(val condominioId: String) : DashboardNavigationEvent()
     data class SearchMorador(val condominioId: String) : DashboardNavigationEvent()
+    data class AmenityList(val condominioId: String) : DashboardNavigationEvent()
     object Logout : DashboardNavigationEvent()
 }
 
@@ -112,6 +113,12 @@ class CondominioDashboardViewModel(
         val condominioId = _uiState.value.condominioId
         if (condominioId.isBlank()) return
         _uiState.update { it.copy(navigationEvent = DashboardNavigationEvent.SearchMorador(condominioId)) }
+    }
+
+    fun onAmenityListClick() {
+        val condominioId = _uiState.value.condominioId
+        if (condominioId.isBlank()) return
+        _uiState.update { it.copy(navigationEvent = DashboardNavigationEvent.AmenityList(condominioId)) }
     }
 
     fun onNavigationHandled() {

--- a/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/CondominioDashboardNavHost.kt
+++ b/features/condominio/ui/src/commonMain/kotlin/com/zalamena/condominios/condominio/ui/condominio/dashboard/navigation/CondominioDashboardNavHost.kt
@@ -14,6 +14,10 @@ import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDas
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDashboardViewModel
 import com.zalamena.condominios.condominio.ui.moradores.details.MoradorInfoScreen
 import com.zalamena.condominios.condominio.ui.moradores.details.MoradorInfoViewModel
+import com.zalamena.condominios.condominio.ui.amenity.add.AddAmenityScreen
+import com.zalamena.condominios.condominio.ui.amenity.add.AddAmenityViewModel
+import com.zalamena.condominios.condominio.ui.amenity.list.AmenityListScreen
+import com.zalamena.condominios.condominio.ui.amenity.list.AmenityListViewModel
 import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListScreen
 import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListViewModel
 import com.zalamena.login.ui.createuser.CreateUserViewModel
@@ -36,6 +40,12 @@ object PorteiroListRoute
 @Serializable
 object AdminMoradorDetailRoute
 
+@Serializable
+object AmenityListRoute
+
+@Serializable
+object AddAmenityRoute
+
 fun NavGraphBuilder.condominioDashboardNavHost(
     navController: NavController,
     viewModel: CondominioDashboardViewModel,
@@ -44,7 +54,9 @@ fun NavGraphBuilder.condominioDashboardNavHost(
     addMoradorFlowViewModel: AddMoradorFlowViewModel,
     createUserViewModel: CreateUserViewModel,
     porteiroListViewModel: PorteiroListViewModel,
-    moradorInfoViewModel: MoradorInfoViewModel
+    moradorInfoViewModel: MoradorInfoViewModel,
+    amenityListViewModel: AmenityListViewModel,
+    addAmenityViewModel: AddAmenityViewModel
 ) {
     navigation<CondominioDashboardRoute>(startDestination = CondominioDashboardScreenRoute) {
         composable<CondominioDashboardScreenRoute> {
@@ -68,6 +80,10 @@ fun NavGraphBuilder.condominioDashboardNavHost(
                 onNavigateToPorteiroList = { condominioId ->
                     porteiroListViewModel.setCondominioId(condominioId)
                     navController.navigate(PorteiroListRoute)
+                },
+                onNavigateToAmenityList = { condominioId ->
+                    amenityListViewModel.setCondominioId(condominioId)
+                    navController.navigate(AmenityListRoute)
                 },
                 onBack = { navController.popBackStack() }
             )
@@ -107,6 +123,26 @@ fun NavGraphBuilder.condominioDashboardNavHost(
         composable<PorteiroListRoute> {
             PorteiroListScreen(
                 viewModel = porteiroListViewModel,
+                onBack = { navController.popBackStack() }
+            )
+        }
+
+        composable<AmenityListRoute> {
+            AmenityListScreen(
+                viewModel = amenityListViewModel,
+                onNavigateToAddAmenity = { condominioId ->
+                    addAmenityViewModel.reset()
+                    addAmenityViewModel.setCondominioId(condominioId)
+                    navController.navigate(AddAmenityRoute)
+                },
+                onBack = { navController.popBackStack() }
+            )
+        }
+
+        composable<AddAmenityRoute> {
+            AddAmenityScreen(
+                viewModel = addAmenityViewModel,
+                onSuccess = { navController.popBackStack() },
                 onBack = { navController.popBackStack() }
             )
         }

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/amenity/AddAmenityViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/amenity/AddAmenityViewModelTest.kt
@@ -1,0 +1,142 @@
+package com.zalamena.condominios.ui.amenity
+
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+import com.zalamena.condominios.condominio.domain.amenity.repository.AmenityRepository
+import com.zalamena.condominios.condominio.domain.amenity.usecase.AddAmenityUseCase
+import com.zalamena.condominios.condominio.ui.amenity.add.AddAmenityNavigationEvent
+import com.zalamena.condominios.condominio.ui.amenity.add.AddAmenityViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.kodein.mock.Mock
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddAmenityViewModelTest : TestsWithMocks() {
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+
+    @Mock
+    lateinit var amenityRepository: AmenityRepository
+
+    private val addAmenityUseCase by lazy { AddAmenityUseCase(amenityRepository) }
+    private val viewModel by lazy { AddAmenityViewModel(addAmenityUseCase) }
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `GIVEN initial state THEN all fields are empty`() {
+        val state = viewModel.uiState.value
+        assertEquals("", state.nome)
+        assertEquals("", state.descricao)
+        assertEquals("", state.capacidade)
+        assertEquals("", state.precoUso)
+        assertFalse(state.requerAprovacaoSindico)
+        assertNull(state.navigationEvent)
+    }
+
+    @Test
+    fun `WHEN setNome THEN nome is updated`() = runTest(testDispatcher) {
+        viewModel.setNome("Salao")
+        assertEquals("Salao", viewModel.uiState.value.nome)
+    }
+
+    @Test
+    fun `WHEN setCapacidade with non-digits THEN non-digits are filtered`() = runTest(testDispatcher) {
+        viewModel.setCapacidade("5a0b")
+        assertEquals("50", viewModel.uiState.value.capacidade)
+    }
+
+    @Test
+    fun `WHEN setPrecoUso THEN only digits are kept`() = runTest(testDispatcher) {
+        viewModel.setPrecoUso("200.50")
+        assertEquals("20050", viewModel.uiState.value.precoUso)
+    }
+
+    @Test
+    fun `GIVEN blank nome WHEN submit THEN nomeError is set`() = runTest(testDispatcher) {
+        viewModel.setCondominioId("condo-1")
+        viewModel.setNome("")
+        viewModel.submit()
+        advanceUntilIdle()
+
+        assertNotNull(viewModel.uiState.value.nomeError)
+        assertNull(viewModel.uiState.value.navigationEvent)
+    }
+
+    @Test
+    fun `GIVEN valid form WHEN submit succeeds THEN navigation event is Success`() = runTest(testDispatcher) {
+        everySuspending { amenityRepository.addAmenity(isAny()) } returns Result.success(Unit)
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.setNome("Salao de Festas")
+        viewModel.setPrecoUso("20000")
+        viewModel.submit()
+        advanceUntilIdle()
+
+        assertIs<AddAmenityNavigationEvent.Success>(viewModel.uiState.value.navigationEvent)
+        assertFalse(viewModel.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `GIVEN valid form WHEN submit fails THEN errorMessage is set`() = runTest(testDispatcher) {
+        everySuspending { amenityRepository.addAmenity(isAny()) } returns Result.failure(Exception("DB error"))
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.setNome("Salao de Festas")
+        viewModel.submit()
+        advanceUntilIdle()
+
+        assertNotNull(viewModel.uiState.value.errorMessage)
+        assertNull(viewModel.uiState.value.navigationEvent)
+    }
+
+    @Test
+    fun `WHEN reset THEN state returns to initial`() = runTest(testDispatcher) {
+        viewModel.setNome("Salao")
+        viewModel.setDescricao("Desc")
+        viewModel.reset()
+
+        assertEquals("", viewModel.uiState.value.nome)
+        assertEquals("", viewModel.uiState.value.descricao)
+    }
+
+    @Test
+    fun `WHEN onNavigationHandled THEN navigationEvent is null`() = runTest(testDispatcher) {
+        everySuspending { amenityRepository.addAmenity(isAny()) } returns Result.success(Unit)
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.setNome("Salao")
+        viewModel.submit()
+        advanceUntilIdle()
+
+        viewModel.onNavigationHandled()
+        assertNull(viewModel.uiState.value.navigationEvent)
+    }
+}

--- a/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/amenity/AmenityListViewModelTest.kt
+++ b/features/condominio/ui/src/commonTest/kotlin/com/zalamena/condominios/ui/amenity/AmenityListViewModelTest.kt
@@ -1,0 +1,117 @@
+package com.zalamena.condominios.ui.amenity
+
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+import com.zalamena.condominios.condominio.domain.amenity.repository.AmenityRepository
+import com.zalamena.condominios.condominio.domain.amenity.usecase.GetAmenitiesByCondominioUseCase
+import com.zalamena.condominios.condominio.ui.amenity.list.AmenityListNavigationEvent
+import com.zalamena.condominios.condominio.ui.amenity.list.AmenityListViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.kodein.mock.Mock
+import org.kodein.mock.generated.injectMocks
+import org.kodein.mock.tests.TestsWithMocks
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AmenityListViewModelTest : TestsWithMocks() {
+
+    override fun setUpMocks() {
+        mocker.injectMocks(this)
+    }
+
+    @Mock
+    lateinit var amenityRepository: AmenityRepository
+
+    private val getAmenitiesByCondominioUseCase by lazy { GetAmenitiesByCondominioUseCase(amenityRepository) }
+    private val viewModel by lazy { AmenityListViewModel(getAmenitiesByCondominioUseCase) }
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `GIVEN initial state THEN amenities is empty`() {
+        assertTrue(viewModel.uiState.value.amenities.isEmpty())
+        assertNull(viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `GIVEN amenities exist WHEN loadAmenities THEN list is populated`() = runTest(testDispatcher) {
+        val amenities = listOf(Amenity.dummy, Amenity.dummy.copy(id = "2", nome = "Churrasqueira"))
+        everySuspending { amenityRepository.getAmenitiesByCondominio("condo-1") } returns Result.success(amenities)
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadAmenities()
+        advanceUntilIdle()
+
+        assertEquals(2, viewModel.uiState.value.amenities.size)
+        assertNull(viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `GIVEN no amenities WHEN loadAmenities THEN list is empty`() = runTest(testDispatcher) {
+        everySuspending { amenityRepository.getAmenitiesByCondominio("condo-1") } returns Result.success(emptyList())
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadAmenities()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.amenities.isEmpty())
+    }
+
+    @Test
+    fun `GIVEN repository fails WHEN loadAmenities THEN error is set`() = runTest(testDispatcher) {
+        everySuspending { amenityRepository.getAmenitiesByCondominio("condo-1") } returns Result.failure(Exception("fail"))
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadAmenities()
+        advanceUntilIdle()
+
+        assertEquals("fail", viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `GIVEN blank condominioId WHEN loadAmenities THEN nothing happens`() = runTest(testDispatcher) {
+        viewModel.loadAmenities()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.amenities.isEmpty())
+        assertNull(viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `WHEN onAddAmenityClick THEN navigation event is set`() = runTest(testDispatcher) {
+        viewModel.setCondominioId("condo-1")
+        viewModel.onAddAmenityClick()
+
+        assertIs<AmenityListNavigationEvent.AddAmenity>(viewModel.uiState.value.navigationEvent)
+    }
+
+    @Test
+    fun `WHEN onNavigationHandled THEN event is cleared`() = runTest(testDispatcher) {
+        viewModel.setCondominioId("condo-1")
+        viewModel.onAddAmenityClick()
+        viewModel.onNavigationHandled()
+
+        assertNull(viewModel.uiState.value.navigationEvent)
+    }
+}

--- a/features/database/schemas/com.zalamena.condominios.database.AppDatabase/3.json
+++ b/features/database/schemas/com.zalamena.condominios.database.AppDatabase/3.json
@@ -1,0 +1,294 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "a57ede1ae9daba0028cee0c2091af536",
+    "entities": [
+      {
+        "tableName": "Morador",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `pessoaId` TEXT NOT NULL, `apartamentoId` TEXT NOT NULL, `tipo` TEXT NOT NULL, FOREIGN KEY(`pessoaId`) REFERENCES `Pessoa`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`apartamentoId`) REFERENCES `Apartamento`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pessoaId",
+            "columnName": "pessoaId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apartamentoId",
+            "columnName": "apartamentoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tipo",
+            "columnName": "tipo",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "Pessoa",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pessoaId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "Apartamento",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "apartamentoId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Apartamento",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `numero` TEXT NOT NULL, `andar` TEXT NOT NULL, `condominioId` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numero",
+            "columnName": "numero",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "andar",
+            "columnName": "andar",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "condominioId",
+            "columnName": "condominioId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "Condominio",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `nome` TEXT NOT NULL, `enderecoId` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`enderecoId`) REFERENCES `EnderecoEntity`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nome",
+            "columnName": "nome",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enderecoId",
+            "columnName": "enderecoId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "EnderecoEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "enderecoId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "EnderecoEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `rua` TEXT NOT NULL, `numero` TEXT NOT NULL, `cep` TEXT NOT NULL, `cidade` TEXT NOT NULL, `estado` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rua",
+            "columnName": "rua",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numero",
+            "columnName": "numero",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cep",
+            "columnName": "cep",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cidade",
+            "columnName": "cidade",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "estado",
+            "columnName": "estado",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "Pessoa",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `nome` TEXT NOT NULL, `cpf` TEXT NOT NULL, `email` TEXT NOT NULL, `telefone` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nome",
+            "columnName": "nome",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cpf",
+            "columnName": "cpf",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "telefone",
+            "columnName": "telefone",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "Amenity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `condominioId` TEXT NOT NULL, `nome` TEXT NOT NULL, `descricao` TEXT NOT NULL, `capacidade` INTEGER, `precoUso` REAL, `requerAprovacaoSindico` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "condominioId",
+            "columnName": "condominioId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nome",
+            "columnName": "nome",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "descricao",
+            "columnName": "descricao",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capacidade",
+            "columnName": "capacidade",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "precoUso",
+            "columnName": "precoUso",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "requerAprovacaoSindico",
+            "columnName": "requerAprovacaoSindico",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a57ede1ae9daba0028cee0c2091af536')"
+    ]
+  }
+}

--- a/features/database/src/commonMain/kotlin/com/zalamena/condominios/database/AppDatabase.kt
+++ b/features/database/src/commonMain/kotlin/com/zalamena/condominios/database/AppDatabase.kt
@@ -1,9 +1,12 @@
 package com.zalamena.condominios.database
 
 import androidx.room.ConstructedBy
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.RoomDatabaseConstructor
+import com.zalamena.condominios.condominio.data.amenity.dao.AmenityDao
+import com.zalamena.condominios.condominio.data.amenity.entity.AmenityEntity
 import com.zalamena.condominios.condominio.data.apartamento.dao.ApartamentoDao
 import com.zalamena.condominios.condominio.data.apartamento.entity.ApartamentoEntity
 import com.zalamena.condominios.condominio.data.condominio.dao.CondominioDao
@@ -14,19 +17,27 @@ import com.zalamena.condominios.condominio.data.moradores.entities.MoradorEntity
 import com.zalamena.condominios.pessoa.data.dao.PessoaDao
 import com.zalamena.condominios.pessoa.data.entities.PessoaEntity
 
-@Database(entities = [
-    MoradorEntity::class,
-    ApartamentoEntity::class,
-    CondominioEntity::class,
-    EnderecoEntity::class,
-    PessoaEntity::class
-], version = 2)
+@Database(
+    entities = [
+        MoradorEntity::class,
+        ApartamentoEntity::class,
+        CondominioEntity::class,
+        EnderecoEntity::class,
+        PessoaEntity::class,
+        AmenityEntity::class
+    ],
+    version = 3,
+    autoMigrations = [
+        AutoMigration(from = 2, to = 3)
+    ]
+)
 @ConstructedBy(AppDatabaseConstructor::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun getMoradoresDao(): MoradoresDao
     abstract fun getApartamentosDao(): ApartamentoDao
     abstract fun getCondominioDao(): CondominioDao
     abstract fun getPessoaDao(): PessoaDao
+    abstract fun getAmenityDao(): AmenityDao
 }
 
 // The Room compiler generates the `actual` implementations.

--- a/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
+++ b/features/di/src/commonMain/kotlin/com/zalamena/condominios/di/modules.kt
@@ -41,6 +41,13 @@ import com.zalamena.condominios.condominio.ui.moradores.details.MoradorInfoViewM
 import com.zalamena.condominios.condominio.ui.addmorador.searchpessoa.SearchPessoaViewModel
 import com.zalamena.condominios.condominio.ui.moradores.search.MoradorSearchViewModel
 import com.zalamena.condominios.condominio.ui.porteiro.list.PorteiroListViewModel
+import com.zalamena.condominios.condominio.ui.amenity.add.AddAmenityViewModel
+import com.zalamena.condominios.condominio.ui.amenity.list.AmenityListViewModel
+import com.zalamena.condominios.condominio.data.amenity.dao.AmenityDao
+import com.zalamena.condominios.condominio.data.amenity.repository.AmenityRepositoryImpl
+import com.zalamena.condominios.condominio.domain.amenity.repository.AmenityRepository
+import com.zalamena.condominios.condominio.domain.amenity.usecase.AddAmenityUseCase
+import com.zalamena.condominios.condominio.domain.amenity.usecase.GetAmenitiesByCondominioUseCase
 import com.zalamena.condominios.navigation.ui.shell.MoradorShellViewModel
 import com.zalamena.condominios.condominio.domain.porteiro.models.PorteiroInfo
 import com.zalamena.condominios.condominio.domain.porteiro.repository.PorteiroDeleter
@@ -104,6 +111,7 @@ val daoModule = module {
     single<ApartamentoDao> { get<AppDatabase>().getApartamentosDao() }
     single<CondominioDao> { get<AppDatabase>().getCondominioDao() }
     single<MoradoresDao> { get<AppDatabase>().getMoradoresDao() }
+    single<AmenityDao> { get<AppDatabase>().getAmenityDao() }
 }
 
 val networkModule = module {
@@ -135,6 +143,7 @@ val repositoryModule = module {
     single<ApartamentosRepository> { ApartamentoRepositoryImpl(get()) }
     single<CondominioRepository> { CondominioRepositoryImpl(get()) }
     single<MoradoresRepository> { MoradoresRepositoryImpl(get()) }
+    single<AmenityRepository> { AmenityRepositoryImpl(get()) }
     single<AddPessoaFormValidator> { AddPessoaFormValidatorImpl() }
     single<LoginApi> { FakeLoginApi(get()) }
     single<SessionRepository> { SessionRepositoryImpl() }
@@ -215,6 +224,8 @@ val useCaseModule = module {
     factory { GetPorteirosByCondominioUseCase(get()) }
     factory { DeletePorteiroUseCase(get()) }
     factory { ReassignPorteiroUseCase(get(), get()) }
+    factory { AddAmenityUseCase(get()) }
+    factory { GetAmenitiesByCondominioUseCase(get()) }
 }
 
 val viewModelModule = module {
@@ -237,4 +248,6 @@ val viewModelModule = module {
     viewModelOf(::MoradorInfoViewModel)
     viewModelOf(::SearchPessoaViewModel)
     viewModelOf(::MoradorShellViewModel)
+    viewModelOf(::AmenityListViewModel)
+    viewModelOf(::AddAmenityViewModel)
 }

--- a/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
+++ b/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/NavHost.kt
@@ -28,6 +28,8 @@ import com.zalamena.condominios.condominio.ui.adminhome.AdminHomeViewModel
 import com.zalamena.condominios.condominio.ui.apartamento.detail.ApartamentoDetailViewModel
 import com.zalamena.condominios.condominio.ui.addmorador.flowController.AddMoradorFlowViewModel
 import com.zalamena.condominios.condominio.ui.addmorador.navigation.addMoradorNavGraph
+import com.zalamena.condominios.condominio.ui.amenity.add.AddAmenityViewModel
+import com.zalamena.condominios.condominio.ui.amenity.list.AmenityListViewModel
 import com.zalamena.condominios.condominio.ui.addmorador.overview.AddMoradorOverviewViewModel
 import com.zalamena.condominios.condominio.ui.addmorador.searchpessoa.SearchPessoaViewModel
 import com.zalamena.condominios.condominio.ui.condominio.dashboard.CondominioDashboardViewModel
@@ -79,6 +81,8 @@ fun AppNavHost(
     moradorInfoViewModel: MoradorInfoViewModel,
     searchPessoaViewModel: SearchPessoaViewModel,
     moradorShellViewModel: MoradorShellViewModel,
+    amenityListViewModel: AmenityListViewModel,
+    addAmenityViewModel: AddAmenityViewModel,
     onLogout: suspend () -> Unit = {}
 ) {
     NavHost(navController, startDestination = SplashRoute) {
@@ -204,7 +208,9 @@ fun AppNavHost(
             addMoradorFlowViewModel,
             createUserViewModel,
             porteiroListViewModel,
-            moradorInfoViewModel
+            moradorInfoViewModel,
+            amenityListViewModel,
+            addAmenityViewModel
         )
 
         addCondominioNavHost(

--- a/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/shell/MoradorShellScreen.kt
+++ b/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/shell/MoradorShellScreen.kt
@@ -3,12 +3,15 @@ package com.zalamena.condominios.navigation.ui.shell
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.filled.CalendarMonth
@@ -43,6 +46,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
 import com.zalamena.login.ui.navigation.LoginRoute
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
@@ -144,7 +148,7 @@ fun MoradorShellScreen(
             modifier = Modifier.padding(innerPadding)
         ) {
             composable<MoradorHomeTab> {
-                MoradorHomeContent(condominioName = uiState.condominioName)
+                MoradorHomeContent(uiState = uiState)
             }
 
             composable<MoradorReservasTab> {
@@ -155,45 +159,118 @@ fun MoradorShellScreen(
 }
 
 @Composable
-fun MoradorHomeContent(condominioName: String) {
-    Column(
+fun MoradorHomeContent(uiState: MoradorShellUiState) {
+    LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp)
+            .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        if (condominioName.isNotEmpty()) {
-            Text(
-                text = condominioName,
-                style = MaterialTheme.typography.headlineMedium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-            Spacer(modifier = Modifier.height(24.dp))
+        if (uiState.condominioName.isNotEmpty()) {
+            item {
+                Text(
+                    text = uiState.condominioName,
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(top = 16.dp)
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+            }
         }
 
-        Text(
-            text = "Comodidades",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-        Spacer(modifier = Modifier.height(12.dp))
-        EmptyStateCard(
-            icon = Icons.Default.LocationCity,
-            message = "Nenhuma comodidade disponivel"
-        )
+        item {
+            Text(
+                text = "Comodidades",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
 
-        Spacer(modifier = Modifier.height(24.dp))
+        if (uiState.amenities.isEmpty()) {
+            item {
+                EmptyStateCard(
+                    icon = Icons.Default.LocationCity,
+                    message = "Nenhuma comodidade disponivel"
+                )
+            }
+        } else {
+            items(uiState.amenities) { amenity ->
+                AmenityCard(amenity)
+            }
+        }
 
-        Text(
-            text = "Minhas Reservas",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-        Spacer(modifier = Modifier.height(12.dp))
-        EmptyStateCard(
-            icon = Icons.Default.CalendarMonth,
-            message = "Nenhuma reserva"
-        )
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Minhas Reservas",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+
+        item {
+            EmptyStateCard(
+                icon = Icons.Default.CalendarMonth,
+                message = "Nenhuma reserva"
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+        }
     }
+}
+
+@Composable
+private fun AmenityCard(amenity: Amenity) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(
+                text = amenity.nome,
+                style = MaterialTheme.typography.titleMedium
+            )
+            if (amenity.descricao.isNotBlank()) {
+                Text(
+                    text = amenity.descricao,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(Modifier.height(4.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                amenity.capacidade?.let { cap ->
+                    Text(
+                        text = "$cap pessoas",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                amenity.precoUso?.let { preco ->
+                    Text(
+                        text = formatBrl(preco),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun formatBrl(value: Double): String {
+    val cents = (value * 100).toLong()
+    val integerPart = cents / 100
+    val decimalPart = (cents % 100).toString().padStart(2, '0')
+    val integerFormatted = integerPart.toString()
+        .reversed()
+        .chunked(3)
+        .joinToString(".")
+        .reversed()
+    return "R$ $integerFormatted,$decimalPart"
 }
 
 @Composable

--- a/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/shell/MoradorShellViewModel.kt
+++ b/features/navigation/ui/src/commonMain/kotlin/com/zalamena/condominios/navigation/ui/shell/MoradorShellViewModel.kt
@@ -2,6 +2,8 @@ package com.zalamena.condominios.navigation.ui.shell
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+import com.zalamena.condominios.condominio.domain.amenity.usecase.GetAmenitiesByCondominioUseCase
 import com.zalamena.condominios.condominio.domain.condominio.usecase.GetCondominioUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -10,12 +12,14 @@ import kotlinx.coroutines.launch
 
 data class MoradorShellUiState(
     val condominioName: String = "",
+    val amenities: List<Amenity> = emptyList(),
     val isLoading: Boolean = false,
     val error: String? = null
 )
 
 class MoradorShellViewModel(
-    private val getCondominioUseCase: GetCondominioUseCase
+    private val getCondominioUseCase: GetCondominioUseCase,
+    private val getAmenitiesByCondominioUseCase: GetAmenitiesByCondominioUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MoradorShellUiState())
@@ -48,6 +52,11 @@ class MoradorShellViewModel(
                             error = e.message ?: "Erro ao carregar condominio"
                         )
                     }
+                }
+
+            getAmenitiesByCondominioUseCase(condominioId)
+                .onSuccess { amenities ->
+                    _uiState.update { it.copy(amenities = amenities) }
                 }
         }
     }

--- a/features/navigation/ui/src/commonTest/kotlin/com/zalamena/condominios/navigation/ui/shell/MoradorShellViewModelTest.kt
+++ b/features/navigation/ui/src/commonTest/kotlin/com/zalamena/condominios/navigation/ui/shell/MoradorShellViewModelTest.kt
@@ -1,5 +1,8 @@
 package com.zalamena.condominios.navigation.ui.shell
 
+import com.zalamena.condominios.condominio.domain.amenity.model.Amenity
+import com.zalamena.condominios.condominio.domain.amenity.repository.AmenityRepository
+import com.zalamena.condominios.condominio.domain.amenity.usecase.GetAmenitiesByCondominioUseCase
 import com.zalamena.condominios.condominio.domain.condominio.models.Condominio
 import com.zalamena.condominios.condominio.domain.condominio.usecase.GetCondominioUseCase
 import kotlinx.coroutines.Dispatchers
@@ -30,8 +33,12 @@ class MoradorShellViewModelTest : TestsWithMocks() {
     @Mock
     lateinit var condominioRepository: CondominioRepository
 
+    @Mock
+    lateinit var amenityRepository: AmenityRepository
+
     private val getCondominioUseCase by lazy { GetCondominioUseCase(condominioRepository) }
-    private val viewModel by lazy { MoradorShellViewModel(getCondominioUseCase) }
+    private val getAmenitiesByCondominioUseCase by lazy { GetAmenitiesByCondominioUseCase(amenityRepository) }
+    private val viewModel by lazy { MoradorShellViewModel(getCondominioUseCase, getAmenitiesByCondominioUseCase) }
 
     private val testDispatcher = StandardTestDispatcher()
 
@@ -57,6 +64,7 @@ class MoradorShellViewModelTest : TestsWithMocks() {
     fun `GIVEN condominioId set WHEN loadCondominio THEN condominioName is updated`() = runTest {
         val condominio = Condominio.dummy.copy(id = "condo-1", nome = "Residencial Sol")
         everySuspending { condominioRepository.getCondominio("condo-1") } returns Result.success(condominio)
+        everySuspending { amenityRepository.getAmenitiesByCondominio("condo-1") } returns Result.success(emptyList())
 
         viewModel.setCondominioId("condo-1")
         viewModel.loadCondominio()
@@ -71,6 +79,7 @@ class MoradorShellViewModelTest : TestsWithMocks() {
     @Test
     fun `GIVEN condominioId set WHEN loadCondominio fails THEN error is set`() = runTest {
         everySuspending { condominioRepository.getCondominio("condo-1") } returns Result.failure(Exception("Not found"))
+        everySuspending { amenityRepository.getAmenitiesByCondominio("condo-1") } returns Result.success(emptyList())
 
         viewModel.setCondominioId("condo-1")
         viewModel.loadCondominio()
@@ -91,5 +100,19 @@ class MoradorShellViewModelTest : TestsWithMocks() {
         assertEquals("", state.condominioName)
         assertTrue(!state.isLoading)
         assertNull(state.error)
+    }
+
+    @Test
+    fun `GIVEN amenities exist WHEN loadCondominio THEN amenities are loaded`() = runTest {
+        val condominio = Condominio.dummy.copy(id = "condo-1", nome = "Residencial Sol")
+        val amenities = listOf(Amenity.dummy, Amenity.dummy.copy(id = "2", nome = "Churrasqueira"))
+        everySuspending { condominioRepository.getCondominio("condo-1") } returns Result.success(condominio)
+        everySuspending { amenityRepository.getAmenitiesByCondominio("condo-1") } returns Result.success(amenities)
+
+        viewModel.setCondominioId("condo-1")
+        viewModel.loadCondominio()
+        advanceUntilIdle()
+
+        assertEquals(2, viewModel.uiState.value.amenities.size)
     }
 }


### PR DESCRIPTION
## Summary
- Full amenity (comodidade) feature: admin can create amenities with name, description, capacity, BRL price, and síndico approval toggle
- Amenity list screen accessible from condominio dashboard "Comodidades" menu
- Price field uses right-to-left BRL currency visual transformation (R$ 0,01 → R$ 0,10 → R$ 1,00)
- Morador home screen now displays real amenity cards from the DB instead of placeholder empty state
- Room DB migrated v2→v3 with AutoMigration for the new Amenity table
- 24 new unit tests across domain and UI layers

Depends on #47 (issue #30)
Closes #31

## Test plan
- [ ] As admin: open condominio → three-dot menu → "Comodidades" → see empty state
- [ ] Tap FAB (+) → fill form with name, price, capacity → submit → amenity appears in list
- [ ] Verify price field formats as BRL (type "150" → shows "R$ 1,50")
- [ ] Try submitting with empty name → validation error appears
- [ ] Toggle "Requer aprovação do síndico" on/off
- [ ] Log in as morador → home screen shows the created amenity cards
- [ ] Run `runCommonTests` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)